### PR TITLE
Focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "@types/rimraf": "^3.0.0",
         "@types/sinon": "^9.0.4",
         "@types/sinon-chai": "^3.2.4",
+        "@types/tabbable": "^3.1.0",
         "@types/webpack": "^4.41.13",
         "@typescript-eslint/eslint-plugin": "^3.0.1",
         "@typescript-eslint/parser": "^3.0.1",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -14,7 +14,8 @@
     },
     "dependencies": {
         "@popperjs/core": "^2.4.0",
-        "@zeejs/core": "^0.0.1"
+        "@zeejs/core": "^0.0.1",
+        "tabbable": "^4.0.0"
     },
     "files": [
         "cjs",

--- a/packages/browser/src/focus.ts
+++ b/packages/browser/src/focus.ts
@@ -23,7 +23,7 @@ const onFocus = (event: FocusEvent) => {
             );
             while (availableLayers.length) {
                 const layer = availableLayers.shift()!;
-                const layerId = layer.dataset.id!;
+                const layerId = layer.id;
                 const origin = document.querySelector<HTMLElement>(`[data-origin="${layerId}"]`);
                 if (origin) {
                     const element = queryFirstTabbable(layer, origin, true);
@@ -70,7 +70,7 @@ function queryNextTabbable(
     const edgeIndex = isForward ? list.length - 1 : 0;
     const currentIndex = list.indexOf(currentElement as HTMLElement);
     if (currentIndex === edgeIndex) {
-        const layerId = layer.dataset.id;
+        const layerId = layer.id;
         if (!layerId) {
             // top layer
             if (isForward) {
@@ -131,7 +131,7 @@ function queryFirstTabbable(
         // ToDo: handle invalid origin element
         return null;
     }
-    const layer = document.querySelector<HTMLElement>(`[data-id="${originId}"]`);
+    const layer = document.querySelector<HTMLElement>(`#${originId}`);
     if (!layer) {
         // skip missing layer
         return queryNextTabbable(originLayer, originElement, isForward);
@@ -151,7 +151,7 @@ function queryFirstTabbable(
     }
 }
 
-function findContainingLayer(element: Element) {
+export function findContainingLayer(element: Element) {
     let current: Element | null = element;
     while (current) {
         if (current.tagName === `ZEEJS-LAYER`) {

--- a/packages/browser/src/focus.ts
+++ b/packages/browser/src/focus.ts
@@ -1,0 +1,128 @@
+import tabbable from 'tabbable';
+
+export function watchFocus(layersWrapper: HTMLElement) {
+    layersWrapper.addEventListener(`keydown`, onKeyDown, { capture: true });
+    return {
+        stop() {
+            layersWrapper.removeEventListener(`keydown`, onKeyDown);
+        },
+    };
+}
+
+const onKeyDown = (event: KeyboardEvent) => {
+    if (event.code === `Tab` && document.activeElement) {
+        const activeElement = document.activeElement;
+        const layer = findContainingLayer(activeElement);
+        const isForward = !event.shiftKey;
+        if (layer && activeElement) {
+            const nextElement = queryNextTabbable(layer, activeElement, isForward);
+            if (nextElement) {
+                event.preventDefault();
+                nextElement.focus();
+            }
+        }
+    }
+};
+
+type Focusable = { focus: () => void };
+
+function queryNextTabbable(
+    layer: HTMLElement,
+    currentElement: Element,
+    isForward: boolean
+): Focusable | null {
+    const list = tabbable(layer);
+    if (list.length === 0) {
+        throw new Error(
+            `queryNextTabbable was called with currentElement that is not contained in layer`
+        );
+    }
+    const edgeIndex = isForward ? list.length - 1 : 0;
+    const currentIndex = list.indexOf(currentElement as HTMLElement);
+    if (currentIndex === edgeIndex) {
+        const layerId = layer.dataset.id;
+        if (!layerId) {
+            // top layer
+            if (isForward) {
+                // loop to start
+                return queryTabbableElement(layer, list[0], isForward);
+            } else {
+                // move backward on root layer - do nothing
+                // let browser navigate to chrome (URL)
+                return null;
+            }
+        } else {
+            // nested layer
+            // ToDo: handle blocking layer
+            const originElement = document.querySelector(`[data-origin="${layerId}"]`);
+            if (!originElement) {
+                // ToDo: handle missing origin?
+                return null;
+            }
+            const originLayer = findContainingLayer(originElement);
+            if (!originLayer) {
+                // ToDo: handle missing origin layer, maybe return originElement?
+                return null;
+            }
+            return queryNextTabbable(originLayer, originElement, isForward);
+        }
+    }
+    const nextIndex = currentIndex + (isForward ? 1 : -1);
+    const nextElement = list[nextIndex];
+    const isOriginElement = nextElement.tagName === `ZEEJS-ORIGIN`;
+    if (isOriginElement) {
+        return queryFirstTabbable(layer, nextElement, isForward);
+    } else {
+        return nextElement;
+    }
+}
+
+function queryTabbableElement(layer: HTMLElement, element: HTMLElement, isForward: boolean) {
+    const isOriginElement = element.tagName === `ZEEJS-ORIGIN`;
+    if (isOriginElement) {
+        return queryFirstTabbable(layer, element, isForward);
+    } else {
+        return element;
+    }
+}
+
+function queryFirstTabbable(
+    originLayer: HTMLElement,
+    originElement: HTMLElement,
+    isForward: boolean
+): Focusable | null {
+    const originId = originElement.dataset.origin;
+    if (!originId) {
+        // ToDo: handle invalid origin element
+        return null;
+    }
+    const layer = document.querySelector<HTMLElement>(`[data-id="${originId}"]`);
+    if (!layer) {
+        // skip missing layer
+        return queryNextTabbable(originLayer, originElement, isForward);
+    }
+    const list = tabbable(layer);
+    if (list.length === 0) {
+        // empty layer - query next after origin element
+        return queryNextTabbable(originLayer, originElement, isForward);
+    }
+    const edgeIndex = isForward ? 0 : list.length - 1;
+    const firstElement = list[edgeIndex];
+    if (firstElement.tagName === `ZEEJS-ORIGIN`) {
+        // query first element in nested layer
+        return queryFirstTabbable(layer, firstElement, isForward);
+    } else {
+        return firstElement;
+    }
+}
+
+function findContainingLayer(element: Element) {
+    let current: Element | null = element;
+    while (current) {
+        if (current.tagName === `ZEEJS-LAYER`) {
+            return current as HTMLElement;
+        }
+        current = current.parentElement;
+    }
+    return null;
+}

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,1 +1,2 @@
 export { bindOverlay } from './bind-overlay';
+export { watchFocus } from './focus';

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,2 +1,5 @@
+export type { DOMLayer } from './root';
+export { defaultLayerSettings, createRoot } from './root';
 export { bindOverlay } from './bind-overlay';
 export { watchFocus } from './focus';
+export { updateLayers, createBackdropParts } from './update-layers';

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,5 +1,5 @@
 export type { DOMLayer } from './root';
-export { defaultLayerSettings, createRoot } from './root';
+export { createRoot } from './root';
 export { bindOverlay } from './bind-overlay';
 export { watchFocus } from './focus';
 export { updateLayers, createBackdropParts } from './update-layers';

--- a/packages/browser/src/root.ts
+++ b/packages/browser/src/root.ts
@@ -1,0 +1,62 @@
+import { createLayer, Layer } from '@zeejs/core';
+import { bindOverlay } from './bind-overlay';
+
+export const overlapBindConfig = Symbol(`overlap-bind`);
+
+export interface LayerSettings {
+    overlap: `window` | HTMLElement;
+    backdrop: `none` | `block` | `hide`;
+}
+export interface LayerExtended {
+    element: HTMLElement;
+    settings: LayerSettings;
+    [overlapBindConfig]: ReturnType<typeof bindOverlay>;
+}
+export type DOMLayer = Layer<LayerExtended, LayerSettings>;
+
+export const defaultLayerSettings: LayerSettings = {
+    overlap: `window`,
+    backdrop: `none`,
+};
+
+export function createRoot() {
+    let idCounter = 0;
+    let wrapper: HTMLElement;
+    const rootLayer = createLayer({
+        extendLayer: {
+            element: (null as unknown) as HTMLElement,
+            settings: defaultLayerSettings,
+        } as DOMLayer,
+        defaultSettings: defaultLayerSettings,
+        init(layer, settings) {
+            layer.settings = settings;
+            layer.element = document.createElement(`zeejs-layer`); // ToDo: test that each layer has a unique element
+            layer.element.id = `zeejs-layer-${idCounter++}`;
+            if (layer.parentLayer) {
+                if (settings.overlap === `window`) {
+                    layer.element.classList.add(`zeejs--overlapWindow`);
+                } else if (settings.overlap instanceof HTMLElement) {
+                    layer.element.classList.add(`zeejs--overlapElement`);
+                    layer[overlapBindConfig] = bindOverlay(settings.overlap, layer.element);
+                }
+            }
+        },
+        destroy(layer) {
+            if (layer[overlapBindConfig]) {
+                layer[overlapBindConfig].stop(); // not tested because its a side effect:/
+            }
+        },
+    });
+    return {
+        setWrapper(rootWrapper: HTMLElement, mainLayer?: HTMLElement) {
+            if (wrapper) {
+                return;
+            }
+            wrapper = rootWrapper;
+            if (mainLayer) {
+                rootLayer.element = mainLayer;
+            }
+        },
+        rootLayer,
+    };
+}

--- a/packages/browser/src/root.ts
+++ b/packages/browser/src/root.ts
@@ -1,4 +1,4 @@
-import { createLayer, Layer, Change } from '@zeejs/core';
+import { createLayer, Layer } from '@zeejs/core';
 import { bindOverlay } from './bind-overlay';
 
 export const overlapBindConfig = Symbol(`overlap-bind`);
@@ -22,7 +22,7 @@ export const defaultLayerSettings: LayerSettings = {
 export function createRoot({
     onChange,
 }: {
-    onChange?: (change: Change<LayerExtended, LayerSettings>) => void;
+    onChange?: () => void;
 } = {}) {
     let idCounter = 0;
     const rootLayer = createLayer({
@@ -31,9 +31,9 @@ export function createRoot({
             settings: defaultLayerSettings,
         } as LayerExtended,
         defaultSettings: defaultLayerSettings,
-        onChange(change) {
+        onChange() {
             if (onChange) {
-                onChange(change);
+                onChange();
             }
         },
         init(layer, settings) {

--- a/packages/browser/src/root.ts
+++ b/packages/browser/src/root.ts
@@ -1,4 +1,4 @@
-import { createLayer, Layer } from '@zeejs/core';
+import { createLayer, Layer, Change } from '@zeejs/core';
 import { bindOverlay } from './bind-overlay';
 
 export const overlapBindConfig = Symbol(`overlap-bind`);
@@ -19,15 +19,23 @@ export const defaultLayerSettings: LayerSettings = {
     backdrop: `none`,
 };
 
-export function createRoot() {
+export function createRoot({
+    onChange,
+}: {
+    onChange?: (change: Change<LayerExtended, LayerSettings>) => void;
+} = {}) {
     let idCounter = 0;
-    let wrapper: HTMLElement;
     const rootLayer = createLayer({
         extendLayer: {
             element: (null as unknown) as HTMLElement,
             settings: defaultLayerSettings,
-        } as DOMLayer,
+        } as LayerExtended,
         defaultSettings: defaultLayerSettings,
+        onChange(change) {
+            if (onChange) {
+                onChange(change);
+            }
+        },
         init(layer, settings) {
             layer.settings = settings;
             layer.element = document.createElement(`zeejs-layer`); // ToDo: test that each layer has a unique element
@@ -47,16 +55,5 @@ export function createRoot() {
             }
         },
     });
-    return {
-        setWrapper(rootWrapper: HTMLElement, mainLayer?: HTMLElement) {
-            if (wrapper) {
-                return;
-            }
-            wrapper = rootWrapper;
-            if (mainLayer) {
-                rootLayer.element = mainLayer;
-            }
-        },
-        rootLayer,
-    };
+    return rootLayer;
 }

--- a/packages/browser/src/update-layers.ts
+++ b/packages/browser/src/update-layers.ts
@@ -1,0 +1,74 @@
+import { DOMLayer } from './root';
+import { findContainingLayer } from './focus';
+
+export function createBackdropParts() {
+    return {
+        block: document.createElement(`zeejs-block`),
+        hide: document.createElement(`zeejs-hide`),
+    };
+}
+
+export function updateLayers(
+    wrapper: HTMLElement,
+    topLayer: DOMLayer,
+    {
+        hide,
+        block,
+    }: {
+        hide: HTMLElement;
+        block: HTMLElement;
+    }
+) {
+    const layers = topLayer.generateDisplayList();
+    let blocking: HTMLElement | null = null;
+    let hiding: HTMLElement | null = null;
+    const layersIds = new Set<string>();
+    // append new layers, set order and find backdrop position
+    for (const [index, { element, settings }] of layers.entries()) {
+        layersIds.add(element.id);
+        element.setAttribute(`z-index`, String(index));
+        if (element.parentElement !== wrapper) {
+            wrapper.appendChild(element);
+        }
+        if (settings.backdrop !== `none`) {
+            blocking = element;
+            if (settings.backdrop === `hide`) {
+                hiding = element;
+            }
+        }
+    }
+    // remove old layers & backdrop
+    const blockedIndex = hiding
+        ? Number(hiding.getAttribute(`z-index`))
+        : blocking
+        ? Number(blocking.getAttribute(`z-index`))
+        : 0;
+    for (const element of Array.from(wrapper.children)) {
+        if (!layersIds.has(element.id)) {
+            wrapper.removeChild(element);
+        } else {
+            if (Number(element.getAttribute(`z-index`)) < blockedIndex) {
+                element.setAttribute(`inert`, ``);
+            } else {
+                element.removeAttribute(`inert`);
+            }
+        }
+    }
+    // append backdrop if needed
+    if (hiding) {
+        wrapper.insertBefore(hide, hiding);
+        hide.setAttribute(`z-index`, hiding.getAttribute(`z-index`)!);
+    }
+    if (blocking) {
+        wrapper.insertBefore(block, blocking);
+        block.setAttribute(`z-index`, blocking.getAttribute(`z-index`)!);
+    }
+    // blur inert active element
+    if (document.activeElement) {
+        const focusedLayer = findContainingLayer(document.activeElement);
+        if (focusedLayer && focusedLayer.hasAttribute(`inert`)) {
+            ((document.activeElement as unknown) as HTMLOrSVGElement).blur();
+        }
+    }
+    return layers;
+}

--- a/packages/browser/test/focus.spec.ts
+++ b/packages/browser/test/focus.spec.ts
@@ -19,7 +19,7 @@ describe(`focus`, () => {
                     <zeejs-origin data-origin="layerX" tabIndex="0">
                     <input id="bgAfterInput" />
                 </zeejs-layer>
-                <zeejs-layer data-id="layerX" >
+                <zeejs-layer id="layerX" >
                     <input id="layerInput" />
                 </zeejs-layer>
             </div>
@@ -56,7 +56,7 @@ describe(`focus`, () => {
                     <zeejs-origin data-origin="layerX" tabIndex="0">
                     <input id="bgAfterInput" />
                 </zeejs-layer>
-                <zeejs-layer data-id="layerX" >
+                <zeejs-layer id="layerX" >
                     <input id="layerInput" />
                 </zeejs-layer>
             </div>
@@ -92,7 +92,7 @@ describe(`focus`, () => {
                     <input id="bgBeforeInput" />
                     <zeejs-origin data-origin="layerX" tabIndex="0">
                 </zeejs-layer>
-                <zeejs-layer data-id="layerX" >
+                <zeejs-layer id="layerX" >
                     <input id="layerInputA" />
                     <input id="layerInputB" />
                 </zeejs-layer>
@@ -126,7 +126,7 @@ describe(`focus`, () => {
                     <zeejs-origin data-origin="layerX" tabIndex="0">
                     <input id="bgAfterInput" />
                 </zeejs-layer>
-                <zeejs-layer data-id="layerX" >
+                <zeejs-layer id="layerX" >
                     <input id="layerInputA" />
                     <input id="layerInputB" />
                 </zeejs-layer>
@@ -161,10 +161,10 @@ describe(`focus`, () => {
                     <zeejs-origin data-origin="layerX" tabIndex="0">
                     <input id="bgAfterInput" />
                 </zeejs-layer>
-                <zeejs-layer data-id="layerX" >
+                <zeejs-layer id="layerX" >
                     <zeejs-origin data-origin="layerY" tabIndex="0">
                 </zeejs-layer>
-                <zeejs-layer data-id="layerY" >
+                <zeejs-layer id="layerY" >
                     <input id="layerDeepInput" />
                 </zeejs-layer>
             </div>
@@ -195,7 +195,7 @@ describe(`focus`, () => {
                     <zeejs-origin data-origin="layerX" tabIndex="0">
                     <input id="bgAfterInput" />
                 </zeejs-layer>
-                <zeejs-layer data-id="layerX" >
+                <zeejs-layer id="layerX" >
                     <span>no tabbable elements />
                 </zeejs-layer>
             </div>
@@ -245,10 +245,10 @@ describe(`focus`, () => {
                     <zeejs-origin data-origin="firstLayer" tabIndex="0">
                     <zeejs-origin data-origin="lastLayer" tabIndex="0">
                 </zeejs-layer>
-                <zeejs-layer data-id="firstLayer" >
+                <zeejs-layer id="firstLayer" >
                     <input id="firstLayerInput" />
                 </zeejs-layer>
-                <zeejs-layer data-id="lastLayer" >
+                <zeejs-layer id="lastLayer" >
                     <input id="lastLayerInput" />
                 </zeejs-layer>
             </div>
@@ -273,7 +273,7 @@ describe(`focus`, () => {
                 <zeejs-layer>
                     <zeejs-origin data-origin="layerX" tabIndex="0">
                 </zeejs-layer>
-                <zeejs-layer data-id="layerX" >
+                <zeejs-layer id="layerX" >
                     <input id="layerInput" />
                 </zeejs-layer>
             </div>
@@ -299,7 +299,7 @@ describe(`focus`, () => {
                     <zeejs-origin data-origin="layerX" tabIndex="0">
                     <input id="bgAfterInput" />
                 </zeejs-layer>
-                <zeejs-layer data-id="layerX" >
+                <zeejs-layer id="layerX" >
                     <input id="layerFirstInput" />
                     <input id="layerLastInput" />
                 </zeejs-layer>
@@ -333,12 +333,12 @@ describe(`focus`, () => {
                     <zeejs-origin data-origin="layerX" tabIndex="0">
                     <input id="bgAfterInput" />
                 </zeejs-layer>
-                <zeejs-layer data-id="layerX" >
+                <zeejs-layer id="layerX" >
                     <input id="layerXFirstInput" />
                     <zeejs-origin data-origin="layerY" tabIndex="0">
                     <input id="layerXLastInput" />
                 </zeejs-layer>
-                <zeejs-layer data-id="layerY" >
+                <zeejs-layer id="layerY" >
                     <input id="layerYInput" />
                 </zeejs-layer>
             </div>
@@ -374,7 +374,7 @@ describe(`focus`, () => {
                     <input id="bgBeforeInput" />
                     <zeejs-origin data-origin="layerX" tabIndex="0">
                 </zeejs-layer>
-                <zeejs-layer data-id="layerX" >
+                <zeejs-layer id="layerX" >
                     <input id="layerInput" />
                 </zeejs-layer>
             </div>

--- a/packages/browser/test/focus.spec.ts
+++ b/packages/browser/test/focus.spec.ts
@@ -1,0 +1,292 @@
+import { watchFocus } from '../src';
+import { HTMLTestDriver } from './html-test-driver';
+import { getInteractionApi } from '@zeejs/test-browser/browser';
+import { expect } from 'chai';
+
+describe(`focus`, () => {
+    let testDriver: HTMLTestDriver;
+    const { keyboard } = getInteractionApi();
+
+    before('setup test driver', () => (testDriver = new HTMLTestDriver()));
+    afterEach('clear test driver', () => testDriver.clean());
+
+    it(`should [Tab] navigate through layer`, async () => {
+        const { expectHTMLQuery, container } = testDriver.render(
+            () => `
+            <div>
+                <zeejs-layer>
+                    <input id="bgBeforeInput" />
+                    <zeejs-origin data-origin="layerX" tabIndex="0">
+                    <input id="bgAfterInput" />
+                </zeejs-layer>
+                <zeejs-layer data-id="layerX" >
+                    <input id="layerInput" />
+                </zeejs-layer>
+            </div>
+        `
+        );
+        watchFocus(container);
+
+        const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
+        const layerInput = expectHTMLQuery(`#layerInput`);
+        const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
+
+        bgBeforeInput.focus();
+        expect(document.activeElement, `start focus before layer`).to.equal(bgBeforeInput);
+
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `focus inside layer`).to.equal(layerInput);
+
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `focus after layer`).to.equal(bgAfterInput);
+
+        // it would be nice to have native behavior (go to browser chrome)
+        // but other layers are in the way of the focus and cannot be skipped
+        // without specifically focusing another element or loosing focus.
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `back to start`).to.equal(bgBeforeInput);
+    });
+
+    it(`should [Shift+Tab] navigate through layer (backwards)`, async () => {
+        const { expectHTMLQuery, container } = testDriver.render(
+            () => `
+            <div>
+                <zeejs-layer>
+                    <input id="bgBeforeInput" />
+                    <zeejs-origin data-origin="layerX" tabIndex="0">
+                    <input id="bgAfterInput" />
+                </zeejs-layer>
+                <zeejs-layer data-id="layerX" >
+                    <input id="layerInput" />
+                </zeejs-layer>
+            </div>
+        `
+        );
+        watchFocus(container);
+
+        const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
+        const layerInput = expectHTMLQuery(`#layerInput`);
+        const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
+
+        bgAfterInput.focus();
+        expect(document.activeElement, `start focus after layer`).to.equal(bgAfterInput);
+
+        await keyboard.press(`Shift+Tab`);
+        expect(document.activeElement, `focus inside layer`).to.equal(layerInput);
+
+        await keyboard.press(`Shift+Tab`);
+        expect(document.activeElement, `focus before layer`).to.equal(bgBeforeInput);
+
+        await keyboard.press(`Shift+Tab`);
+        const activeReturnedToChrome =
+            document.activeElement === document.body ||
+            document.activeElement === document.body.parentElement; // html in firefox
+        expect(activeReturnedToChrome, `focus on browser chrome`).to.equal(true);
+    });
+
+    it(`should [Tab] navigate from layer that is the last tabbable element`, async () => {
+        const { expectHTMLQuery, container } = testDriver.render(
+            () => `
+            <div>
+                <zeejs-layer>
+                    <input id="bgBeforeInput" />
+                    <zeejs-origin data-origin="layerX" tabIndex="0">
+                </zeejs-layer>
+                <zeejs-layer data-id="layerX" >
+                    <input id="layerInputA" />
+                    <input id="layerInputB" />
+                </zeejs-layer>
+            </div>
+        `
+        );
+        watchFocus(container);
+
+        const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
+        const layerInputA = expectHTMLQuery(`#layerInputA`);
+        const layerInputB = expectHTMLQuery(`#layerInputB`);
+
+        bgBeforeInput.focus();
+        expect(document.activeElement, `start focus before layer`).to.equal(bgBeforeInput);
+
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `first focus inside layer`).to.equal(layerInputA);
+
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `second focus inside layer`).to.equal(layerInputB);
+
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `back to start`).to.equal(bgBeforeInput);
+    });
+
+    it(`should [Shift+Tab] navigate from layer that is the first tabbable element (backwards)`, async () => {
+        const { expectHTMLQuery, container } = testDriver.render(
+            () => `
+            <div>
+                <zeejs-layer>
+                    <zeejs-origin data-origin="layerX" tabIndex="0">
+                    <input id="bgAfterInput" />
+                </zeejs-layer>
+                <zeejs-layer data-id="layerX" >
+                    <input id="layerInputA" />
+                    <input id="layerInputB" />
+                </zeejs-layer>
+            </div>
+        `
+        );
+        watchFocus(container);
+
+        const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
+        const layerInputA = expectHTMLQuery(`#layerInputA`);
+        const layerInputB = expectHTMLQuery(`#layerInputB`);
+
+        bgAfterInput.focus();
+        expect(document.activeElement, `start focus after layer`).to.equal(bgAfterInput);
+
+        await keyboard.press(`Shift+Tab`);
+        expect(document.activeElement, `second focus inside layer`).to.equal(layerInputB);
+
+        await keyboard.press(`Shift+Tab`);
+        expect(document.activeElement, `first focus inside layer`).to.equal(layerInputA);
+
+        await keyboard.press(`Shift+Tab`);
+        expect(document.activeElement, `back to start`).to.equal(bgAfterInput);
+    });
+
+    it(`should [Tab] into deeply nested layer`, async () => {
+        const { expectHTMLQuery, container } = testDriver.render(
+            () => `
+            <div>
+                <zeejs-layer>
+                    <input id="bgBeforeInput" />
+                    <zeejs-origin data-origin="layerX" tabIndex="0">
+                    <input id="bgAfterInput" />
+                </zeejs-layer>
+                <zeejs-layer data-id="layerX" >
+                    <zeejs-origin data-origin="layerY" tabIndex="0">
+                </zeejs-layer>
+                <zeejs-layer data-id="layerY" >
+                    <input id="layerDeepInput" />
+                </zeejs-layer>
+            </div>
+        `
+        );
+        watchFocus(container);
+
+        const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
+        const layerDeepInput = expectHTMLQuery(`#layerDeepInput`);
+        const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
+
+        bgBeforeInput.focus();
+        expect(document.activeElement, `start focus before layer`).to.equal(bgBeforeInput);
+
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `focus inside deep layer`).to.equal(layerDeepInput);
+
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `focus after layers`).to.equal(bgAfterInput);
+    });
+
+    it(`should [Tab] over layer with no tabbable elements`, async () => {
+        const { expectHTMLQuery, container } = testDriver.render(
+            () => `
+            <div>
+                <zeejs-layer>
+                    <input id="bgBeforeInput" />
+                    <zeejs-origin data-origin="layerX" tabIndex="0">
+                    <input id="bgAfterInput" />
+                </zeejs-layer>
+                <zeejs-layer data-id="layerX" >
+                    <span>no tabbable elements />
+                </zeejs-layer>
+            </div>
+        `
+        );
+        watchFocus(container);
+
+        const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
+        const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
+
+        bgBeforeInput.focus();
+        expect(document.activeElement, `start focus before layer`).to.equal(bgBeforeInput);
+
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `focus after layer`).to.equal(bgAfterInput);
+    });
+
+    it(`should [Tab] skip over missing layer`, async () => {
+        const { expectHTMLQuery, container } = testDriver.render(
+            () => `
+            <div>
+                <zeejs-layer>
+                    <input id="bgBeforeInput" />
+                    <zeejs-origin data-origin="layerX" tabIndex="0">
+                    <input id="bgAfterInput" />
+                </zeejs-layer>
+            </div>
+        `
+        );
+        watchFocus(container);
+
+        const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
+        const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
+
+        bgBeforeInput.focus();
+        expect(document.activeElement, `start focus before layer`).to.equal(bgBeforeInput);
+
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `focus after layer`).to.equal(bgAfterInput);
+    });
+
+    it(`should [Tab] out of edge layer and into first layer`, async () => {
+        const { expectHTMLQuery, container } = testDriver.render(
+            () => `
+            <div>
+                <zeejs-layer>
+                    <zeejs-origin data-origin="firstLayer" tabIndex="0">
+                    <zeejs-origin data-origin="lastLayer" tabIndex="0">
+                </zeejs-layer>
+                <zeejs-layer data-id="firstLayer" >
+                    <input id="firstLayerInput" />
+                </zeejs-layer>
+                <zeejs-layer data-id="lastLayer" >
+                    <input id="lastLayerInput" />
+                </zeejs-layer>
+            </div>
+        `
+        );
+        watchFocus(container);
+
+        const firstLayerInput = expectHTMLQuery(`#firstLayerInput`);
+        const lastLayerInput = expectHTMLQuery(`#lastLayerInput`);
+
+        lastLayerInput.focus();
+        expect(document.activeElement, `start in last layer input`).to.equal(lastLayerInput);
+
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `focus first layer input`).to.equal(firstLayerInput);
+    });
+
+    it(`should [Tab] back to input on a single input`, async () => {
+        const { expectHTMLQuery, container } = testDriver.render(
+            () => `
+            <div>
+                <zeejs-layer>
+                    <zeejs-origin data-origin="layerX" tabIndex="0">
+                </zeejs-layer>
+                <zeejs-layer data-id="layerX" >
+                    <input id="layerInput" />
+                </zeejs-layer>
+            </div>
+        `
+        );
+        watchFocus(container);
+
+        const layerInput = expectHTMLQuery(`#layerInput`);
+
+        layerInput.focus();
+        expect(document.activeElement, `start in only input`).to.equal(layerInput);
+
+        await keyboard.press(`Tab`);
+        expect(document.activeElement, `back to start`).to.equal(layerInput);
+    });
+});

--- a/packages/browser/test/update-layers.spec.ts
+++ b/packages/browser/test/update-layers.spec.ts
@@ -315,4 +315,33 @@ describe(`update-layers`, () => {
 
         expect(document.activeElement, `top focus not changed`).to.equal(topLayerInput);
     });
+
+    it(`should optionally blur/refocus asynchronically`, async () => {
+        const { container: wrapper } = testDriver.render(() => ``);
+        const rootLayer = createRoot();
+        const rootInput = document.createElement(`input`);
+        rootLayer.element.appendChild(rootInput);
+        wrapper.appendChild(rootLayer.element);
+        rootInput.focus();
+        const blockingLayer = rootLayer.createLayer({
+            settings: { backdrop: `block`, overlap: `window` },
+        });
+
+        const waitForBlur = updateLayers(wrapper, rootLayer, backdropParts, true /*async*/);
+
+        expect(document.activeElement, `no sync blur`).to.equal(rootInput);
+
+        await waitForBlur;
+
+        expect(document.activeElement, `async blur`).to.be.oneOf([null, document.body]);
+
+        rootLayer.removeLayer(blockingLayer);
+        const waitForRefocus = updateLayers(wrapper, rootLayer, backdropParts, true /*async*/);
+
+        expect(document.activeElement, `no sync blur`).to.be.oneOf([null, document.body]);
+
+        await waitForRefocus;
+
+        expect(document.activeElement, `async re-focus`).to.equal(rootInput);
+    });
 });

--- a/packages/browser/test/update-layers.spec.ts
+++ b/packages/browser/test/update-layers.spec.ts
@@ -1,0 +1,230 @@
+import { updateLayers, createRoot, createBackdropParts } from '../src';
+import { HTMLTestDriver } from './html-test-driver';
+import { expect } from 'chai';
+
+describe(`update-layers`, () => {
+    let testDriver: HTMLTestDriver;
+    const backdropParts = createBackdropParts();
+
+    before('setup test driver', () => (testDriver = new HTMLTestDriver()));
+    afterEach('clear test driver', () => testDriver.clean());
+
+    it(`should append root layer`, () => {
+        const { rootLayer, setWrapper } = createRoot();
+        const wrapper = document.createElement(`div`);
+        setWrapper(wrapper);
+
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(wrapper.children.length, `root layer`).to.equal(1);
+        expect(wrapper.children[0], `root`).to.equal(rootLayer.element);
+    });
+
+    it(`should append child layer after root layer`, () => {
+        const { rootLayer, setWrapper } = createRoot();
+        const wrapper = document.createElement(`div`);
+        setWrapper(wrapper);
+
+        const childLayer = rootLayer.createLayer();
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(wrapper.children.length, `root & child layers`).to.equal(2);
+        expect(wrapper.children[0], `root`).to.equal(rootLayer.element);
+        expect(wrapper.children[1], `child`).to.equal(childLayer.element);
+    });
+
+    it(`should append multiple changes (before first layer update)`, () => {
+        const { rootLayer, setWrapper } = createRoot();
+        const wrapper = document.createElement(`div`);
+        setWrapper(wrapper);
+
+        const layerA = rootLayer.createLayer();
+        const layerAChild = layerA.createLayer();
+        const layerB = rootLayer.createLayer();
+        const layerBChild = layerB.createLayer();
+        layerA.removeLayer(layerAChild);
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(wrapper.children.length, `root, A, B & BChild layers`).to.equal(4);
+        expect(wrapper.children[0], `root`).to.equal(rootLayer.element);
+        expect(wrapper.children[1], `layerA`).to.equal(layerA.element);
+        expect(wrapper.children[2], `layerB`).to.equal(layerB.element);
+        expect(wrapper.children[3], `layerBChild`).to.equal(layerBChild.element);
+    });
+
+    it(`should remove layers`, () => {
+        const { rootLayer, setWrapper } = createRoot();
+        const wrapper = document.createElement(`div`);
+        setWrapper(wrapper);
+
+        const layerA = rootLayer.createLayer();
+        const layerAChild = layerA.createLayer();
+        const layerB = rootLayer.createLayer();
+        const layerBChild = layerB.createLayer();
+
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(wrapper.children.length, `root, A, AChild, B & BChild layers`).to.equal(5);
+
+        layerA.removeLayer(layerAChild);
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(wrapper.children.length, `root, A, B & BChild layers`).to.equal(4);
+        expect(wrapper.children[0], `root`).to.equal(rootLayer.element);
+        expect(wrapper.children[1], `layerA`).to.equal(layerA.element);
+        expect(wrapper.children[2], `layerB`).to.equal(layerB.element);
+        expect(wrapper.children[3], `layerBChild`).to.equal(layerBChild.element);
+    });
+
+    it(`should add a layer between layers`, () => {
+        const { rootLayer, setWrapper } = createRoot();
+        const wrapper = document.createElement(`div`);
+        setWrapper(wrapper);
+        const layerA = rootLayer.createLayer();
+        const layerB = rootLayer.createLayer();
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        const layerAChild = layerA.createLayer();
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(wrapper.children.length, `root, A, AChild, B`).to.equal(4);
+        expect(wrapper.children[0], `root`).to.equal(rootLayer.element);
+        expect(wrapper.children[1], `layerA`).to.equal(layerA.element);
+        expect(wrapper.children[2], `layerB`).to.equal(layerB.element);
+        expect(wrapper.children[3], `layerAChild`).to.equal(layerAChild.element);
+        expect(wrapper.children[0].getAttribute(`z-index`), `root 1st`).to.equal(`0`);
+        expect(wrapper.children[1].getAttribute(`z-index`), `layerA 2nd`).to.equal(`1`);
+        expect(wrapper.children[3].getAttribute(`z-index`), `layerAChild 3rd`).to.equal(`2`);
+        expect(wrapper.children[2].getAttribute(`z-index`), `layerB 4th`).to.equal(`3`);
+        // ToDo: add a screen snapshot test
+    });
+
+    it(`should place block element before last layer with backdrop=block`, () => {
+        const { rootLayer, setWrapper } = createRoot();
+        const wrapper = document.createElement(`div`);
+        setWrapper(wrapper);
+
+        const firstLayer = rootLayer.createLayer({
+            settings: { backdrop: `block`, overlap: `window` },
+        });
+        const secondLayer = rootLayer.createLayer({
+            settings: { backdrop: `block`, overlap: `window` },
+        });
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(wrapper.children.length, `root, first, block, second`).to.equal(4);
+        expect(wrapper.children[0], `root`).to.equal(rootLayer.element);
+        expect(wrapper.children[1], `firstLayer`).to.equal(firstLayer.element);
+        expect(wrapper.children[2], `block`).to.equal(backdropParts.block);
+        expect(wrapper.children[3], `secondLayer`).to.equal(secondLayer.element);
+    });
+
+    it(`should place hide+block element before last layer with backdrop=hide`, () => {
+        const { rootLayer, setWrapper } = createRoot();
+        const wrapper = document.createElement(`div`);
+        setWrapper(wrapper);
+
+        const firstLayer = rootLayer.createLayer({
+            settings: { backdrop: `hide`, overlap: `window` },
+        });
+        const secondLayer = rootLayer.createLayer({
+            settings: { backdrop: `hide`, overlap: `window` },
+        });
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(wrapper.children.length, `root, first, hide, block, second`).to.equal(5);
+        expect(wrapper.children[0], `root`).to.equal(rootLayer.element);
+        expect(wrapper.children[1], `firstLayer`).to.equal(firstLayer.element);
+        expect(wrapper.children[2], `hide`).to.equal(backdropParts.hide);
+        expect(wrapper.children[3], `block`).to.equal(backdropParts.block);
+        expect(wrapper.children[4], `secondLayer`).to.equal(secondLayer.element);
+    });
+
+    it(`should place hide & block separately before last layers with backdrop=hide/block`, () => {
+        const { rootLayer, setWrapper } = createRoot();
+        const wrapper = document.createElement(`div`);
+        setWrapper(wrapper);
+
+        const firstLayer = rootLayer.createLayer({
+            settings: { backdrop: `hide`, overlap: `window` },
+        });
+        const secondLayer = rootLayer.createLayer({
+            settings: { backdrop: `block`, overlap: `window` },
+        });
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(wrapper.children.length, `root, hide, first, block, second`).to.equal(5);
+        expect(wrapper.children[0], `root`).to.equal(rootLayer.element);
+        expect(wrapper.children[1], `hide`).to.equal(backdropParts.hide);
+        expect(wrapper.children[2], `firstLayer`).to.equal(firstLayer.element);
+        expect(wrapper.children[3], `block`).to.equal(backdropParts.block);
+        expect(wrapper.children[4], `secondLayer`).to.equal(secondLayer.element);
+    });
+
+    it(`should set attribute inert for all layers before backdrop=block`, () => {
+        const { rootLayer, setWrapper } = createRoot();
+        const wrapper = document.createElement(`div`);
+        setWrapper(wrapper);
+
+        rootLayer.createLayer({ settings: { backdrop: `block`, overlap: `window` } });
+        const secondLayer = rootLayer.createLayer({
+            settings: { backdrop: `hide`, overlap: `window` },
+        });
+        secondLayer.createLayer();
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(wrapper.children.length, `root, first, hide, block, second, secondChild`).to.equal(
+            6
+        );
+        expect(wrapper.children[0].hasAttribute(`inert`), `root inert`).to.equal(true);
+        expect(wrapper.children[1].hasAttribute(`inert`), `firstLayer inert`).to.equal(true);
+        expect(wrapper.children[2].hasAttribute(`inert`), `hide not inert`).to.equal(false);
+        expect(wrapper.children[3].hasAttribute(`inert`), `block not inert`).to.equal(false);
+        expect(wrapper.children[4].hasAttribute(`inert`), `secondLayer not inert`).to.equal(false);
+        expect(wrapper.children[5].hasAttribute(`inert`), `secondLayer child not inert`).to.equal(
+            false
+        );
+
+        rootLayer.removeLayer(secondLayer);
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(wrapper.children.length, `root, block, first`).to.equal(3);
+        expect(wrapper.children[0].hasAttribute(`inert`), `root inert after change`).to.equal(true);
+        expect(wrapper.children[1].hasAttribute(`inert`), `block not inert after change`).to.equal(
+            false
+        );
+        expect(
+            wrapper.children[2].hasAttribute(`inert`),
+            `firstLayer not inert after change`
+        ).to.equal(false);
+    });
+
+    it(`should keep focus within a layer`, () => {
+        const { container: wrapper } = testDriver.render(() => ``);
+        const { rootLayer, setWrapper } = createRoot();
+        setWrapper(wrapper);
+        const rootInput = document.createElement(`input`);
+        rootLayer.element.appendChild(rootInput);
+        wrapper.appendChild(rootLayer.element);
+        rootInput.focus();
+
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(document.activeElement).to.equal(rootInput);
+    });
+
+    it(`should blur within an inert layer`, () => {
+        const { container: wrapper } = testDriver.render(() => ``);
+        const { rootLayer, setWrapper } = createRoot();
+        setWrapper(wrapper);
+        const rootInput = document.createElement(`input`);
+        rootLayer.element.appendChild(rootInput);
+        wrapper.appendChild(rootLayer.element);
+        rootInput.focus();
+        rootLayer.createLayer({ settings: { backdrop: `block`, overlap: `window` } });
+
+        updateLayers(wrapper, rootLayer, backdropParts);
+
+        expect(document.activeElement, `blur inert`).to.be.oneOf([null, document.body]);
+    });
+});

--- a/packages/react/src/layer.tsx
+++ b/packages/react/src/layer.tsx
@@ -32,9 +32,9 @@ export const Layer = ({ children, overlap = `window`, backdrop = `none` }: Layer
 
     return (
         <zeejsContext.Provider value={layer}>
-            <span style={{ display: `none` }}>
+            <zeejs-origin tabIndex={0} data-origin={layer.element.dataset.id}>
                 {layer.element ? ReactDOM.createPortal(children, layer.element) : null}
-            </span>
+            </zeejs-origin>
         </zeejsContext.Provider>
     );
 };

--- a/packages/react/src/layer.tsx
+++ b/packages/react/src/layer.tsx
@@ -32,7 +32,7 @@ export const Layer = ({ children, overlap = `window`, backdrop = `none` }: Layer
 
     return (
         <zeejsContext.Provider value={layer}>
-            <zeejs-origin tabIndex={0} data-origin={layer.element.dataset.id}>
+            <zeejs-origin tabIndex={0} data-origin={layer.element.id}>
                 {layer.element ? ReactDOM.createPortal(children, layer.element) : null}
             </zeejs-origin>
         </zeejsContext.Provider>

--- a/packages/react/src/root.tsx
+++ b/packages/react/src/root.tsx
@@ -61,10 +61,8 @@ export const Root = ({ className, style, children }: RootProps) => {
                 if (!wrapper) {
                     return;
                 }
-                // ToDo: fix: "unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering"
-                // Layer component creates layer, causing sync changes to wrapper DOM.
-                // React console.error with "Warning: unstable_flushDiscreteUpdates" when there is a focused element withing a changing DOM element.
-                updateLayers(wrapper, rootLayer, parts);
+                // buffer delay blur/re-focus because Layer renders and updates during render
+                updateLayers(wrapper, rootLayer, parts, /*asyncFocusChange*/ true);
             },
         });
         return { rootLayer, parts };

--- a/packages/react/src/root.tsx
+++ b/packages/react/src/root.tsx
@@ -94,6 +94,13 @@ export const Root = ({ className, style, children }: RootProps) => {
                 root.appendChild(parts.block);
             }
             root.appendChild(element);
+            element.removeAttribute(`inert`);
+        }
+        const indexOfBlock = Array.from(root.children).indexOf(parts.block);
+        if (indexOfBlock !== -1) {
+            for (let i = indexOfBlock; i >= 0; --i) {
+                root.children[i].setAttribute(`inert`, ``);
+            }
         }
     }, []);
 

--- a/packages/react/test/test.spec.tsx
+++ b/packages/react/test/test.spec.tsx
@@ -11,7 +11,7 @@ chai.use(domElementMatchers);
 
 describe(`react`, () => {
     let testDriver: ReactTestDriver;
-    const { click, clickIfPossible } = getInteractionApi();
+    const { click, clickIfPossible, keyboard } = getInteractionApi();
 
     before('setup test driver', () => (testDriver = new ReactTestDriver()));
     afterEach('clear test driver', () => testDriver.clean());
@@ -371,6 +371,32 @@ describe(`react`, () => {
             await expectImageSnapshot({
                 filePath: `backdrop/should hide content between layer (backdrop=hide)`,
             });
+        });
+    });
+
+    describe(`focus`, () => {
+        it(`should keep layer as part of tab order`, async () => {
+            const { expectHTMLQuery } = testDriver.render<boolean>(() => (
+                <Root>
+                    <input id="bgBeforeInput" />
+                    <Layer>
+                        <input id="layerInput" />
+                    </Layer>
+                    <input id="bgAfterInput" />
+                </Root>
+            ));
+            const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
+            const layerInput = expectHTMLQuery(`#layerInput`);
+            const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
+
+            bgBeforeInput.focus();
+            expect(document.activeElement, `start focus before layer`).to.equal(bgBeforeInput);
+
+            await keyboard.press(`Tab`);
+            expect(document.activeElement, `focus inside layer`).to.equal(layerInput);
+
+            await keyboard.press(`Tab`);
+            expect(document.activeElement, `focus after layer`).to.equal(bgAfterInput);
         });
     });
 });

--- a/packages/react/test/test.spec.tsx
+++ b/packages/react/test/test.spec.tsx
@@ -398,5 +398,26 @@ describe(`react`, () => {
             await keyboard.press(`Tab`);
             expect(document.activeElement, `focus after layer`).to.equal(bgAfterInput);
         });
+
+        it(`should trap focus in blocking layer`, async () => {
+            const { expectHTMLQuery } = testDriver.render<boolean>(() => (
+                <Root>
+                    <input id="bgBeforeInput" />
+                    <Layer backdrop="block">
+                        <input id="layerFirstInput" />
+                        <input id="layerLastInput" />
+                    </Layer>
+                    <input id="bgAfterInput" />
+                </Root>
+            ));
+            const layerFirstInput = expectHTMLQuery(`#layerFirstInput`);
+            const layerLastInput = expectHTMLQuery(`#layerLastInput`);
+
+            layerLastInput.focus();
+            expect(document.activeElement, `start focus in layer`).to.equal(layerLastInput);
+
+            await keyboard.press(`Tab`);
+            expect(document.activeElement, `ignore blocked parent`).to.equal(layerFirstInput);
+        });
     });
 });

--- a/packages/react/test/test.spec.tsx
+++ b/packages/react/test/test.spec.tsx
@@ -419,5 +419,27 @@ describe(`react`, () => {
             await keyboard.press(`Tab`);
             expect(document.activeElement, `ignore blocked parent`).to.equal(layerFirstInput);
         });
+
+        it(`should re-focus last element of an un-blocked layer`, () => {
+            const { expectHTMLQuery, setData } = testDriver.render<boolean>(
+                (renderLayer) => (
+                    <Root>
+                        <input id="bgInput" />
+                        {renderLayer ? <Layer backdrop="block">layer content</Layer> : null}
+                    </Root>
+                ),
+                { initialData: false }
+            );
+            const bgInput = expectHTMLQuery(`#bgInput`);
+            bgInput.focus();
+
+            setData(true);
+
+            expect(document.activeElement, `blocked input blur`).to.equal(document.body);
+
+            setData(false);
+
+            expect(document.activeElement, `refocus input`).to.equal(bgInput);
+        });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,6 +1207,11 @@
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
 
+"@types/tabbable@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/tabbable/-/tabbable-3.1.0.tgz#540d4c2729872560badcc220e73c9412c1d2bffe"
+  integrity sha512-LL0q/bTlzseaXQ8j91eZ+Z8FQUzo0nwkng00B8365qULvFyiSOWylxV8m31Gmee3QuidkDqR72a9NRfR8s4qTw==
+
 "@types/tapable@*", "@types/tapable@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
@@ -7885,6 +7890,11 @@ supports-color@^7.1.0:
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
+
+tabbable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"
+  integrity sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
This PR adds focus handling to layers.

- [x] redirect focus between layers on `[Tab]` / `[Shift+Tab]`
- [x] `focus trap` inside a layer with inert background
- [x] return focus to last focused element when layer is back on top

**Leftovers**:
- [Tab navigation and focus trap behavior research](https://github.com/idoros/zeejs/issues/11). 
