### PR TITLE
Fix Svelte publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 -   **layers** - automatic ordering of nested layers
 -   **backdrop** - hide / block background **or** keep a layer as part of the flow
 -   **focus**
-    - <kbd>Tab</kbd> between layers
-    - trap focus above backdrop
-    - re-focus when blocking layer close
+    -   <kbd>Tab</kbd> between layers
+    -   trap focus above backdrop
+    -   re-focus when blocking layer close
 -   **click outside** - notification for click outside of logical layer
 -   **server rendering** - single pass nested rendering of layers in the server
 -   **typed** - built with [TypeScript](https://www.typescriptlang.org/)
@@ -27,10 +27,10 @@
 -   [read the docs](./docs/documentation.md)
 -   pick your renderer:
 
-| Package                     | Published                                                                                                                         | Size                                                                                               |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| [React](./packages/react)   | [![npm version](https://img.shields.io/npm/v/@zeejs/react.svg?label=@zeejs/react)](https://www.npmjs.com/package/@zeejs/react)    | ![npm bundle size (scoped)](https://img.shields.io/bundlephobia/minzip/@zeejs/react?label=minzip)  |
-| [Svelte](./packages/svelte) | [![npm version](https://img.shields.io/npm/v/@zeejs/svelte.svg?label=@zeejs/svelte)](https://www.npmjs.com/package/@zeejs/svelte) | ![npm bundle size (scoped)](https://img.shields.io/bundlephobia/minzip/@zeejs/svelte?label=minzip) |
+| Package                     | Published                                                                                                                 | Size                                                                                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| [React](./packages/react)   | [![npm version](https://badgen.net/npm/v/@zeejs/react?label=@zeejs/react)](https://www.npmjs.com/package/@zeejs/react)    | [![npm bundle size](https://badgen.net/bundlephobia/minzip/@zeejs/react?label=minzip)](https://bundlephobia.com/result?p=@zeejs/react)   |
+| [Svelte](./packages/svelte) | [![npm version](https://badgen.net/npm/v/@zeejs/svelte?label=@zeejs/svelte)](https://www.npmjs.com/package/@zeejs/svelte) | [![npm bundle size](https://badgen.net/bundlephobia/minzip/@zeejs/svelte?label=minzip)](https://bundlephobia.com/result?p=@zeejs/svelte) |
 
 ## caveats
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -2,7 +2,7 @@
 
 **zeejs** is built as a pure javascript, html & css library with published wrappers for specific rendering libraries / frameworks. This document describes the general behavior and terminology under the hood.
 
-> APIs for supported wrappers are located in their package README: [React](https://www.github.com/idoros/zeejs/packages/react), [Svelte](https://www.github.com/idoros/zeejs/packages/svelte)
+> APIs for supported wrappers are located in their package README: [React](https://github.com/idoros/zeejs/tree/master/packages/react), [Svelte](https://github.com/idoros/zeejs/tree/master/packages/svelte)
 
 ## layers
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "prettify": "npx prettier \"packages/**/*.{js,ts,tsx}\" --write"
     },
     "devDependencies": {
+        "@file-services/node": "^2.2.0",
         "@ts-tools/build": "^1.2.6",
         "@ts-tools/node": "^1.1.3",
         "@ts-tools/webpack-loader": "^1.1.4",
@@ -38,6 +39,7 @@
         "css-loader": "^3.5.3",
         "eslint": "^7.2.0",
         "eslint-config-prettier": "^6.11.0",
+        "glob": "^7.1.6",
         "html-webpack-plugin": "^4.3.0",
         "lerna": "^3.22.0",
         "mini-css-extract-plugin": "^0.9.0",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -5,8 +5,8 @@
 **zeejs React** - simple API to create multi layered UI
 
 ![test status](https://github.com/idoros/zeejs/workflows/test/badge.svg)
-[![npm version](https://img.shields.io/npm/v/@zeejs/react.svg?label=@zeejs/react)](https://www.npmjs.com/package/@zeejs/react)
-![npm bundle size](https://img.shields.io/bundlephobia/minzip/@zeejs/react?label=minzip)
+[![npm version](https://badgen.net/npm/v/@zeejs/react?label=@zeejs/react)](https://www.npmjs.com/package/@zeejs/react)
+[![npm bundle size](https://badgen.net/bundlephobia/minzip/@zeejs/react?label=minzip)](https://bundlephobia.com/result?p=@zeejs/react)
 </p>
 
 ## what's in the box
@@ -24,7 +24,7 @@
 
 ## how to use
 
-This document describes the zeejs React usage, For a more in depth overview of `zeejs`, please see the general [documentation](http://www.github.com/idoros/zeejs/docs/documentation.md).
+This document describes the zeejs React usage, For a more in depth overview of `zeejs`, please see the general [documentation](https://github.com/idoros/zeejs/blob/master/docs/documentation.md).
 
 ### `<Root>` component
 
@@ -71,9 +71,9 @@ The component will generate a new zeejs layer above layer it is rendered in.
 
 | name             | type                        | default  | required | description                                                                                                  |
 | ---------------- | --------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------ |
-| `backdrop`       | "none" \| "block" \| "hide" | "none"   | false    | background behavior; [see docs](http://www.github.com/idoros/zeejs/docs.documentation.md#backdrop)           |
+| `backdrop`       | "none" \| "block" \| "hide" | "none"   | false    | background behavior; [see docs](https://github.com/idoros/zeejs/blob/master/docs/documentation.md#backdrop)           |
 | `overlap`        | "window" \| HTMLElement    | "window" | false    | layer bounds reference                                                                                       |
-| `onClickOutside` | () => void                |          | false    | invoked on click outside; [see docs](http://www.github.com/idoros/zeejs/docs.documentation.md#click-outside) |
+| `onClickOutside` | () => void                |          | false    | invoked on click outside; [see docs](https://github.com/idoros/zeejs/blob/master/docs/documentation.md#click-outside) |
 
 **code example:**
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zeejs/react",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "React layering",
     "author": "Ido Rosenthal",
     "main": "./cjs/index.js",

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -5,8 +5,9 @@
 **zeejs Svelte** - simple API to create multi layered UI
 
 ![test status](https://github.com/idoros/zeejs/workflows/test/badge.svg)
-[![npm version](https://img.shields.io/npm/v/@zeejs/svelte.svg?label=@zeejs/svelte)](https://www.npmjs.com/package/@zeejs/svelte)
-![npm bundle size](https://img.shields.io/bundlephobia/minzip/@zeejs/svelte?label=minzip)
+[![npm version](https://badgen.net/npm/v/@zeejs/svelte?label=@zeejs/svelte)](https://www.npmjs.com/package/@zeejs/svelte)
+[![npm bundle size](https://badgen.net/bundlephobia/minzip/@zeejs/svelte?label=minzip)](https://bundlephobia.com/result?p=@zeejs/svelte)
+
 </p>
 
 ## what's in the box
@@ -14,9 +15,9 @@
 -   **layers** - automatic ordering of nested layers
 -   **backdrop** - hide / block background **or** keep a layer as part of the flow
 -   **focus**
-    - <kbd>Tab</kbd> between layers
-    - trap focus above backdrop
-    - re-focus when blocking layer close
+    -   <kbd>Tab</kbd> between layers
+    -   trap focus above backdrop
+    -   re-focus when blocking layer close
 -   **click outside** - notification for click outside of logical layer
 -   **server rendering** - single pass nested rendering of layers in the server
 -   **typed** - built with [TypeScript](https://www.typescriptlang.org/)
@@ -24,7 +25,7 @@
 
 ## how to use
 
-This document describes the zeejs Svelte usage, For a more in depth overview of `zeejs`, please see the general [documentation](http://www.github.com/idoros/zeejs/docs/documentation.md).
+This document describes the zeejs Svelte usage, For a more in depth overview of `zeejs`, please see the general [documentation](https://github.com/idoros/zeejs/blob/master/docs/documentation.md).
 
 ### `<Root>` component
 
@@ -62,11 +63,11 @@ The component will generate a new zeejs layer above layer it is rendered in.
 
 **props:**
 
-| name             | type                        | default  | required | description                                                                                                  |
-| ---------------- | --------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------ |
-| `backdrop`       | "none" \| "block" \| "hide" | "none"   | false    | background behavior; [see docs](http://www.github.com/idoros/zeejs/docs.documentation.md#backdrop)           |
-| `overlap`        | "window" \| HTMLElement    | "window" | false    | layer bounds reference                                                                                       |
-| `onClickOutside` | () => void                |          | false    | invoked on click outside; [see docs](http://www.github.com/idoros/zeejs/docs.documentation.md#click-outside) |
+| name             | type                        | default  | required | description                                                                                                           |
+| ---------------- | --------------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `backdrop`       | "none" \| "block" \| "hide" | "none"   | false    | background behavior; [see docs](https://github.com/idoros/zeejs/blob/master/docs/documentation.md#backdrop)           |
+| `overlap`        | "window" \| HTMLElement     | "window" | false    | layer bounds reference                                                                                                |
+| `onClickOutside` | () => void                  |          | false    | invoked on click outside; [see docs](https://github.com/idoros/zeejs/blob/master/docs/documentation.md#click-outside) |
 
 **code example:**
 

--- a/packages/svelte/build-svelte.js
+++ b/packages/svelte/build-svelte.js
@@ -1,0 +1,29 @@
+const svelteCompiler = require(`svelte/compiler`);
+const glob = require(`glob`);
+const path = require(`path`);
+const nodeFs = require(`@file-services/node`).nodeFs;
+
+const cjsOutPath = path.join(__dirname, `./cjs`);
+const esmOutPath = path.join(__dirname, `./esm`);
+const srcPath = path.join(__dirname, `./src`);
+
+const sveltePattern = `**/*.svelte`;
+
+for (const compRelativePath of glob.sync(sveltePattern, { absolute: false, cwd: srcPath })) {
+    const compAbsPath = path.join(srcPath, compRelativePath);
+    const compSource = nodeFs.readFileSync(compAbsPath, `utf8`);
+
+    const svelteEsm = svelteCompiler.compile(compSource, {
+        format: `esm`,
+        generate: `dom`,
+        hydratable: true,
+        css: true,
+    });
+
+    nodeFs.ensureDirectorySync(path.join(esmOutPath, path.dirname(compRelativePath)));
+    nodeFs.ensureDirectorySync(path.join(cjsOutPath, path.dirname(compRelativePath)));
+
+    nodeFs.writeFileSync(path.join(esmOutPath, compRelativePath + `.js`), svelteEsm.js.code);
+    nodeFs.writeFileSync(path.join(esmOutPath, compRelativePath), compSource);
+    nodeFs.writeFileSync(path.join(cjsOutPath, compRelativePath), compSource);
+}

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zeejs/svelte",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Svelte layering",
     "author": "Ido Rosenthal",
     "main": "./cjs/index.js",
@@ -9,7 +9,7 @@
     "svelte": "esm/index.js",
     "scripts": {
         "clean": "rimraf ./cjs ./esm",
-        "build": "ts-build ./src --cjs --esm",
+        "build": "ts-build ./src --cjs --esm && node build-svelte.js",
         "test": "node -r @ts-tools/node/r -r tsconfig-paths/register ./test/setup.ts",
         "prepack": "yarn build",
         "demo": "webpack-dev-server"


### PR DESCRIPTION
`@zeejs/svelte` didn't build source files (*.svelte) to `esm/cjs`.

Honestly I'm not sure what is the best practice for publishing Svelte components, but it seems that if you have a Svelte project, you would want the 3rd party source files so you can configure how to build/use them.

In addition I added a `.svelte.js` file next to each `.svelte` file in the `esm` output to allow [bundelphobia](https://bundlephobia.com/result?p=@zeejs/svelte) to pickup the size of the package for browser bundling. Hopefully no one that would use a build with Svelte would pickup `.svelte.js` files before `.svelte` files 🤞 .