### PR TITLE
fix svelte publish - 2nd attempt

### DIFF
--- a/packages/svelte/build-svelte.js
+++ b/packages/svelte/build-svelte.js
@@ -5,9 +5,12 @@ const nodeFs = require(`@file-services/node`).nodeFs;
 
 const cjsOutPath = path.join(__dirname, `./cjs`);
 const esmOutPath = path.join(__dirname, `./esm`);
+const esmBrowserOutPath = path.join(__dirname, `./dist`);
 const srcPath = path.join(__dirname, `./src`);
 
 const sveltePattern = `**/*.svelte`;
+
+nodeFs.copyDirectorySync(esmOutPath, esmBrowserOutPath);
 
 for (const compRelativePath of glob.sync(sveltePattern, { absolute: false, cwd: srcPath })) {
     const compAbsPath = path.join(srcPath, compRelativePath);
@@ -20,10 +23,11 @@ for (const compRelativePath of glob.sync(sveltePattern, { absolute: false, cwd: 
         css: true,
     });
 
+    nodeFs.ensureDirectorySync(path.join(esmBrowserOutPath, path.dirname(compRelativePath)));
     nodeFs.ensureDirectorySync(path.join(esmOutPath, path.dirname(compRelativePath)));
     nodeFs.ensureDirectorySync(path.join(cjsOutPath, path.dirname(compRelativePath)));
 
-    nodeFs.writeFileSync(path.join(esmOutPath, compRelativePath + `.js`), svelteEsm.js.code);
+    nodeFs.writeFileSync(path.join(esmBrowserOutPath, compRelativePath + `.js`), svelteEsm.js.code);
     nodeFs.writeFileSync(path.join(esmOutPath, compRelativePath), compSource);
     nodeFs.writeFileSync(path.join(cjsOutPath, compRelativePath), compSource);
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,14 +1,15 @@
 {
     "name": "@zeejs/svelte",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Svelte layering",
     "author": "Ido Rosenthal",
     "main": "./cjs/index.js",
     "module": "esm/index.js",
+    "browser": "dist/index.js",
     "types": "esm/index.d.ts",
     "svelte": "esm/index.js",
     "scripts": {
-        "clean": "rimraf ./cjs ./esm",
+        "clean": "rimraf ./cjs ./esm ./dist",
         "build": "ts-build ./src --cjs --esm && node build-svelte.js",
         "test": "node -r @ts-tools/node/r -r tsconfig-paths/register ./test/setup.ts",
         "prepack": "yarn build",
@@ -25,6 +26,7 @@
     "files": [
         "cjs",
         "esm",
+        "dist",
         "src"
     ],
     "engines": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zeejs/svelte",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Svelte layering",
     "author": "Ido Rosenthal",
     "main": "./cjs/index.js",
@@ -12,7 +12,7 @@
         "clean": "rimraf ./cjs ./esm ./dist",
         "build": "ts-build ./src --cjs --esm && node build-svelte.js",
         "test": "node -r @ts-tools/node/r -r tsconfig-paths/register ./test/setup.ts",
-        "prepack": "yarn build",
+        "prepack": "yarn clean && yarn build",
         "demo": "webpack-dev-server"
     },
     "dependencies": {


### PR DESCRIPTION
[Bundlephobia](https://bundlephobia.com/result?p=@zeejs/svelte) still picks up to `.svelte` files over the `.svelte.js` files 😠, I added a `dist` folder which is a copy of the `esm` folder with compiled versions of the `.svelte` files and referred to it in the `browser` field of the `package.json`.