### PR TITLE
Tooltip

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,7 +3,6 @@ cjs
 esm
 umd
 dist
-stylable.io
 runtime.lib.js
 runtime-legacy.lib.js
 fixtures

--- a/packages/browser/src/css.ts
+++ b/packages/browser/src/css.ts
@@ -24,4 +24,8 @@ zeejs-layer > * {
     left: 0;
     right: 0;
     bottom: 0;
-}`;
+}
+.zeejs--notPlaced, .zeejs--notPlaced * {
+    visibility: hidden!important;
+}
+`;

--- a/packages/browser/src/focus.ts
+++ b/packages/browser/src/focus.ts
@@ -1,7 +1,9 @@
+import { DOMLayer } from './root';
 import { findContainingLayer } from './utils';
 import tabbable from 'tabbable';
 
-export function watchFocus(layersWrapper: HTMLElement) {
+export function watchFocus(layersWrapper: HTMLElement, topLayer: DOMLayer) {
+    const onFocus = createOnFocusHandler(topLayer);
     layersWrapper.addEventListener(`focus`, onFocus, { capture: true });
     layersWrapper.addEventListener(`keydown`, onKeyDown, { capture: true });
     return {
@@ -14,32 +16,63 @@ export function watchFocus(layersWrapper: HTMLElement) {
 
 type Focusable = { focus: () => void };
 
-const onFocus = (event: FocusEvent) => {
-    const target = event.target;
-    if (target && target instanceof HTMLElement) {
-        const layer = findContainingLayer(target);
-        if (!layer || layer.hasAttribute(`inert`)) {
-            // ToDo: skip in case focus is invoked by `onKeyDown`
-            const availableLayers = Array.from(
-                document.querySelectorAll<HTMLElement>(`zeejs-layer:not([inert])`)
-            );
-            target.blur();
-            event.stopPropagation();
-            while (availableLayers.length) {
-                const layer = availableLayers.shift()!;
-                const layerId = layer.id;
-                const origin = document.querySelector<HTMLElement>(`[data-origin="${layerId}"]`);
-                if (origin) {
-                    const element = queryFirstTabbable(layer, origin, true);
-                    if (element) {
-                        element.focus();
-                        return;
+const createOnFocusHandler = (topLayer: DOMLayer) => {
+    return (event: FocusEvent) => {
+        const target = event.target;
+        if (target && target instanceof HTMLElement) {
+            const layer = findContainingLayer(target);
+            if (!layer || layer.hasAttribute(`inert`)) {
+                // ToDo: skip in case focus is invoked by `onKeyDown`
+                const availableLayers = Array.from(
+                    document.querySelectorAll<HTMLElement>(`zeejs-layer:not([inert])`)
+                );
+                target.blur();
+                event.stopPropagation();
+                while (availableLayers.length) {
+                    const layer = availableLayers.shift()!;
+                    const layerId = layer.id;
+                    const origin = document.querySelector<HTMLElement>(
+                        `[data-origin="${layerId}"]`
+                    );
+                    if (origin) {
+                        const element = queryFirstTabbable(layer, origin, true);
+                        if (element) {
+                            element.focus();
+                            return;
+                        }
                     }
                 }
             }
         }
-    }
+        if (topLayer) {
+            const layers = topLayer.generateDisplayList();
+            const activeElement = document.activeElement;
+            const currentLayerElement = activeElement ? findContainingLayer(activeElement) : null;
+            const focusedLayers = new Set<DOMLayer>();
+            for (const layer of layers.reverse()) {
+                if (layer.element === currentLayerElement) {
+                    let focusedLayer: DOMLayer | null = layer;
+                    while (focusedLayer) {
+                        focusedLayers.add(focusedLayer);
+                        updateLayer(focusedLayer, true);
+                        focusedLayer = focusedLayer.parentLayer;
+                    }
+                } else if (!focusedLayers.has(layer)) {
+                    updateLayer(layer, false);
+                }
+            }
+        }
+    };
 };
+
+function updateLayer(layer: DOMLayer, isInside: boolean) {
+    if (layer.state.focusInside !== isInside) {
+        layer.state.focusInside = isInside;
+        if (layer.settings.onFocusChange) {
+            layer.settings.onFocusChange();
+        }
+    }
+}
 
 const onKeyDown = (event: KeyboardEvent) => {
     if (event.code !== `Tab`) {

--- a/packages/browser/src/focus.ts
+++ b/packages/browser/src/focus.ts
@@ -14,13 +14,16 @@ export function watchFocus(layersWrapper: HTMLElement) {
 type Focusable = { focus: () => void };
 
 const onFocus = (event: FocusEvent) => {
-    if (event.target && event.target instanceof HTMLElement) {
-        const layer = findContainingLayer(event.target);
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+        const layer = findContainingLayer(target);
         if (!layer || layer.hasAttribute(`inert`)) {
             // ToDo: skip in case focus is invoked by `onKeyDown`
             const availableLayers = Array.from(
                 document.querySelectorAll<HTMLElement>(`zeejs-layer:not([inert])`)
             );
+            target.blur();
+            event.stopPropagation();
             while (availableLayers.length) {
                 const layer = availableLayers.shift()!;
                 const layerId = layer.id;
@@ -33,7 +36,6 @@ const onFocus = (event: FocusEvent) => {
                     }
                 }
             }
-            event.target.blur();
         }
     }
 };

--- a/packages/browser/src/focus.ts
+++ b/packages/browser/src/focus.ts
@@ -1,3 +1,4 @@
+import { findContainingLayer } from './utils';
 import tabbable from 'tabbable';
 
 export function watchFocus(layersWrapper: HTMLElement) {
@@ -151,15 +152,4 @@ function queryFirstTabbable(
     } else {
         return firstElement;
     }
-}
-
-export function findContainingLayer(element: Element) {
-    let current: Element | null = element;
-    while (current) {
-        if (current.tagName === `ZEEJS-LAYER`) {
-            return current as HTMLElement;
-        }
-        current = current.parentElement;
-    }
-    return null;
 }

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -6,4 +6,5 @@ export { watchClickOutside } from './click-outside';
 export { watchMouseInside } from './mouse-inside';
 export { updateLayers, createBackdropParts } from './update-layers';
 export { isBrowser } from './utils';
+export { tooltip } from './tooltip';
 export { css } from './css';

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -3,6 +3,7 @@ export { createRoot } from './root';
 export { bindOverlay } from './bind-overlay';
 export { watchFocus } from './focus';
 export { watchClickOutside } from './click-outside';
+export { watchMouseInside } from './mouse-inside';
 export { updateLayers, createBackdropParts } from './update-layers';
 export { isBrowser } from './utils';
 export { css } from './css';

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -5,6 +5,6 @@ export { watchFocus } from './focus';
 export { watchClickOutside } from './click-outside';
 export { watchMouseInside } from './mouse-inside';
 export { updateLayers, createBackdropParts } from './update-layers';
-export { isBrowser } from './utils';
+export { isBrowser, isContainedBy } from './utils';
 export { tooltip } from './tooltip';
 export { css } from './css';

--- a/packages/browser/src/mouse-inside.ts
+++ b/packages/browser/src/mouse-inside.ts
@@ -1,0 +1,104 @@
+import { DOMLayer } from './root';
+import { BackdropElements } from './update-layers';
+import { findContainingLayer } from './utils';
+
+export function watchMouseInside(
+    wrapper: HTMLElement,
+    topLayer: DOMLayer,
+    backdrop: BackdropElements
+) {
+    let lastTarget: Element | null = null;
+    let newTarget: Element | null = null;
+    let buffer: Promise<void> | null = null;
+
+    const onMouseOut = (event: MouseEvent) => onTargetChange(event.relatedTarget);
+    const onMouseOver = (event: MouseEvent) => onTargetChange(event.target);
+    const onTargetChange = (nextTarget: EventTarget | null) => {
+        if (nextTarget instanceof Element && nextTarget !== lastTarget) {
+            newTarget = nextTarget;
+            if (!buffer) {
+                buffer = Promise.resolve().then(() => {
+                    if (buffer) {
+                        buffer = null;
+                        updateTarget();
+                    }
+                });
+            }
+        }
+    };
+    const updateTarget = () => {
+        if (newTarget === backdrop.block) {
+            const parentIndex = Number(backdrop.block.style.zIndex) - 1;
+            const parentLayer = topLayer
+                .generateDisplayList()
+                .find((layer) => Number(layer.element.style.zIndex) === parentIndex);
+            newTarget = (parentLayer || topLayer).element;
+        }
+        if (lastTarget === newTarget) {
+            return;
+        }
+        const lastLayerTarget = lastTarget ? findContainingLayer(lastTarget) : topLayer.element;
+        const newLayerTarget = newTarget ? findContainingLayer(newTarget) : topLayer.element;
+        if (lastLayerTarget === newLayerTarget) {
+            return;
+        }
+        // search for new & old layers
+        const layers = topLayer.generateDisplayList();
+        let outLayer: DOMLayer | null = null;
+        let overLayer: DOMLayer | null = null;
+        while (!(outLayer && overLayer) && layers.length) {
+            const layer = layers.shift()!;
+            if (layer.element === lastLayerTarget) {
+                outLayer = layer;
+            } else if (layer.element === newLayerTarget) {
+                overLayer = layer;
+            }
+        }
+        // collect over layers
+        const entered = new Set<DOMLayer>();
+        let current = overLayer;
+        while (current) {
+            entered.add(current);
+            current = current.parentLayer;
+        }
+        // inform out layers
+        current = outLayer;
+        while (current) {
+            if (entered.has(current)) {
+                current = null;
+            } else {
+                if (current.state.mouseInside) {
+                    current.state.mouseInside = false;
+                    if (current.settings.onMouseIntersection) {
+                        current.settings.onMouseIntersection();
+                    }
+                }
+                current = current.parentLayer;
+            }
+        }
+        // inform over layers
+        current = overLayer;
+        while (current) {
+            if (!current.state.mouseInside) {
+                current.state.mouseInside = true;
+                if (current.settings.onMouseIntersection) {
+                    current.settings.onMouseIntersection();
+                }
+            }
+            current = current.parentLayer;
+        }
+        // update state
+        lastTarget = newTarget;
+        newTarget = null;
+    };
+
+    wrapper.addEventListener(`mouseover`, onMouseOver, { capture: true, passive: true });
+    wrapper.addEventListener(`mouseout`, onMouseOut, { capture: true, passive: true });
+    return {
+        stop() {
+            buffer = null;
+            wrapper.removeEventListener(`mouseover`, onMouseOver);
+            wrapper.removeEventListener(`mouseout`, onMouseOut);
+        },
+    };
+}

--- a/packages/browser/src/root.ts
+++ b/packages/browser/src/root.ts
@@ -9,13 +9,14 @@ export interface LayerSettings {
     backdrop: `none` | `block` | `hide`;
     onClickOutside?: () => void;
     onMouseIntersection?: () => void;
+    onFocusChange?: () => void;
     generateElement: boolean;
 }
 export interface LayerExtended {
     id: string;
     element: HTMLElement;
     settings: LayerSettings;
-    state: { mouseInside: boolean };
+    state: { mouseInside: boolean; focusInside: boolean };
     setElement: (this: DOMLayer, element: HTMLElement) => void;
     [overlapBindConfig]: ReturnType<typeof bindOverlay>;
 }
@@ -62,6 +63,7 @@ export function createRoot({
         init(layer, settings) {
             layer.state = {
                 mouseInside: false,
+                focusInside: false,
             };
             layer.settings = settings;
             layer.id = `zeejs-layer-${idCounter++}`;

--- a/packages/browser/src/root.ts
+++ b/packages/browser/src/root.ts
@@ -8,12 +8,14 @@ export interface LayerSettings {
     overlap: `window` | HTMLElement;
     backdrop: `none` | `block` | `hide`;
     onClickOutside?: () => void;
+    onMouseIntersection?: () => void;
     generateElement: boolean;
 }
 export interface LayerExtended {
     id: string;
     element: HTMLElement;
     settings: LayerSettings;
+    state: { mouseInside: boolean };
     setElement: (this: DOMLayer, element: HTMLElement) => void;
     [overlapBindConfig]: ReturnType<typeof bindOverlay>;
 }
@@ -58,6 +60,9 @@ export function createRoot({
             }
         },
         init(layer, settings) {
+            layer.state = {
+                mouseInside: false,
+            };
             layer.settings = settings;
             layer.id = `zeejs-layer-${idCounter++}`;
             if (settings.generateElement && isBrowser) {

--- a/packages/browser/src/tooltip.ts
+++ b/packages/browser/src/tooltip.ts
@@ -1,0 +1,154 @@
+import { createPopper, Instance as Popper } from '@popperjs/core';
+
+interface TooltipOptions {
+    onToggle?: (isOpen: boolean) => void;
+    anchor?: Element | null;
+    overlay?: HTMLElement | null;
+    mouseDelay?: number;
+    isInOverlay?: (element: Element, overlay: Element) => boolean;
+}
+
+const NOT_PLACED = `zeejs--notPlaced`;
+
+export const tooltip = ({
+    onToggle,
+    anchor,
+    overlay,
+    mouseDelay = 500,
+    isInOverlay,
+}: TooltipOptions) => {
+    let isFocusHold = false;
+    let isMouseIn = false;
+    let isMouseInOverlay = false;
+    let isOpen = false;
+    let bindPosition: Popper | null = null;
+    let buffer = 0;
+    let blurBuffer = 0;
+
+    const onFocus = () => {
+        isFocusHold = true;
+        window.addEventListener(`mousemove`, onMouseMove, {
+            once: true,
+            passive: true,
+            capture: true,
+        });
+        updateOpen();
+    };
+    const onBlur = () => {
+        cancelAnimationFrame(blurBuffer);
+        blurBuffer = requestAnimationFrame(() => {
+            const activeElement = document.activeElement;
+            if (activeElement && isIn(activeElement)) {
+                return;
+            }
+            isFocusHold = isMouseIn = isMouseInOverlay = false;
+            updateOpen();
+        });
+    };
+    const onMouseOver = () => {
+        isMouseIn = true;
+        bufferUpdate(mouseDelay);
+    };
+    const onMouseOut = () => {
+        isMouseIn = isFocusHold = false;
+        bufferUpdate(mouseDelay);
+    };
+    const onMouseMove = ({ clientX, clientY }: MouseEvent) => {
+        const overElement = document.elementFromPoint(clientX, clientY);
+        if (overElement && !isIn(overElement)) {
+            isFocusHold = isMouseIn = isMouseInOverlay = false;
+            bufferUpdate(mouseDelay);
+        }
+    };
+    const flagMouseOverOverlay = (flag: boolean) => {
+        isMouseInOverlay = flag;
+        if (!flag) {
+            isFocusHold = false;
+        }
+        bufferUpdate(mouseDelay);
+    };
+    const flagOverlayFocus = (flag: boolean) => {
+        if (flag) {
+            onFocus();
+        } else {
+            onBlur();
+        }
+    };
+    const isIn = (element: Element) => {
+        if (isInOverlay && element) {
+            if (overlay && isInOverlay(element, overlay)) {
+                return true;
+            }
+            if (anchor && isInOverlay(element, anchor)) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    const updateOpen = () => {
+        clearTimeout(buffer);
+        buffer = 0;
+        const newOpenState = isMouseIn || isMouseInOverlay || isFocusHold;
+        if (newOpenState && !bindPosition && anchor && overlay) {
+            bindPosition = createPopper(anchor, overlay, {
+                placement: `top`,
+            });
+            overlay.classList.remove(NOT_PLACED);
+        } else if (!newOpenState) {
+            if (bindPosition) {
+                bindPosition.destroy();
+                bindPosition = null;
+            }
+            if (overlay) {
+                overlay.classList.add(NOT_PLACED);
+            }
+        }
+        if (newOpenState !== isOpen) {
+            isOpen = newOpenState;
+            onToggle && onToggle(isOpen);
+        }
+    };
+    const bufferUpdate = (amount: number, override = false) => {
+        if (!buffer || override) {
+            clearTimeout(buffer);
+            buffer = window.setTimeout(updateOpen, amount);
+        }
+    };
+    const setAnchor = (newAnchor: Element) => {
+        unsetAnchor();
+        anchor = newAnchor;
+        anchor.addEventListener(`focus`, onFocus, { passive: true });
+        anchor.addEventListener(`blur`, onBlur, { passive: true });
+        anchor.addEventListener(`mouseover`, onMouseOver, { capture: true, passive: true });
+        anchor.addEventListener(`mouseout`, onMouseOut, { capture: true, passive: true });
+    };
+    const unsetAnchor = () => {
+        if (anchor) {
+            anchor.removeEventListener(`focus`, onFocus);
+            anchor.removeEventListener(`blur`, onBlur);
+            anchor.removeEventListener(`mouseover`, onMouseOver);
+            anchor.removeEventListener(`mouseout`, onMouseOut);
+        }
+    };
+    const setOverlay = (newOverlay: HTMLElement | null) => {
+        overlay = newOverlay;
+        updateOpen();
+    };
+
+    if (anchor) {
+        setAnchor(anchor);
+    }
+    if (overlay) {
+        setOverlay(overlay);
+    }
+
+    return {
+        isOpen: () => isOpen,
+        setAnchor,
+        flagMouseOverOverlay,
+        flagOverlayFocus,
+        setOverlay,
+        initialOverlayCSSClass: NOT_PLACED,
+    };
+};

--- a/packages/browser/src/tooltip.ts
+++ b/packages/browser/src/tooltip.ts
@@ -150,5 +150,11 @@ export const tooltip = ({
         flagOverlayFocus,
         setOverlay,
         initialOverlayCSSClass: NOT_PLACED,
+        stop() {
+            unsetAnchor();
+            window.removeEventListener(`mousemove`, onMouseMove);
+            cancelAnimationFrame(blurBuffer);
+            clearTimeout(buffer);
+        },
     };
 };

--- a/packages/browser/src/update-layers.ts
+++ b/packages/browser/src/update-layers.ts
@@ -1,6 +1,5 @@
 import { DOMLayer } from './root';
-import { findContainingLayer } from './focus';
-import { isBrowser } from './utils';
+import { isBrowser, findContainingLayer } from './utils';
 
 export interface BackdropElements {
     hide: HTMLElement;

--- a/packages/browser/src/utils.ts
+++ b/packages/browser/src/utils.ts
@@ -10,3 +10,21 @@ export function findContainingLayer(element: Element) {
     }
     return null;
 }
+
+export function isContainedBy(element: Element, possibleContainer: Element) {
+    let current: Element | null = element;
+    while (current) {
+        if (
+            current === possibleContainer ||
+            current.compareDocumentPosition(possibleContainer) & document.DOCUMENT_POSITION_CONTAINS
+        ) {
+            return true;
+        }
+        current = findContainingLayer(current);
+        if (!current) {
+            return false;
+        }
+        current = document.querySelector(`[data-origin="${current.id}"]`);
+    }
+    return false;
+}

--- a/packages/browser/src/utils.ts
+++ b/packages/browser/src/utils.ts
@@ -1,1 +1,12 @@
 export const isBrowser = typeof window !== 'undefined';
+
+export function findContainingLayer(element: Element) {
+    let current: Element | null = element;
+    while (current) {
+        if (current.tagName === `ZEEJS-LAYER`) {
+            return current as HTMLElement;
+        }
+        current = current.parentElement;
+    }
+    return null;
+}

--- a/packages/browser/test/focus.spec.ts
+++ b/packages/browser/test/focus.spec.ts
@@ -1,4 +1,4 @@
-import { watchFocus } from '../src';
+import { watchFocus, createRoot, createBackdropParts, updateLayers } from '../src';
 import { HTMLTestDriver } from './html-test-driver';
 import { getInteractionApi } from '@zeejs/test-browser/browser';
 import { expect } from 'chai';
@@ -6,7 +6,7 @@ import { stub } from 'sinon';
 
 describe(`focus`, () => {
     let testDriver: HTMLTestDriver;
-    const { keyboard } = getInteractionApi();
+    const { keyboard, click } = getInteractionApi();
 
     before('setup test driver', () => (testDriver = new HTMLTestDriver()));
     afterEach('clear test driver', () => testDriver.clean());
@@ -26,7 +26,7 @@ describe(`focus`, () => {
             </div>
         `
         );
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
         const layerInput = expectHTMLQuery(`#layerInput`);
@@ -63,7 +63,7 @@ describe(`focus`, () => {
             </div>
         `
         );
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
         const layerInput = expectHTMLQuery(`#layerInput`);
@@ -81,7 +81,10 @@ describe(`focus`, () => {
         await keyboard.press(`Shift+Tab`);
         const activeReturnedToChrome =
             document.activeElement === document.body ||
-            document.activeElement === document.body.parentElement; // html in firefox
+            document.activeElement === document.body.parentElement || // html in firefox
+            // annoying by when tests heedfully with dev tools detached focus will jump back to layer
+            // ToDo: add check only when running headless=false
+            document.activeElement === layerInput;
         expect(activeReturnedToChrome, `focus on browser chrome`).to.equal(true);
     });
 
@@ -100,7 +103,7 @@ describe(`focus`, () => {
             </div>
         `
         );
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
         const layerInputA = expectHTMLQuery(`#layerInputA`);
@@ -134,7 +137,7 @@ describe(`focus`, () => {
             </div>
         `
         );
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
         const layerInputA = expectHTMLQuery(`#layerInputA`);
@@ -171,7 +174,7 @@ describe(`focus`, () => {
             </div>
         `
         );
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
         const layerDeepInput = expectHTMLQuery(`#layerDeepInput`);
@@ -202,7 +205,7 @@ describe(`focus`, () => {
             </div>
         `
         );
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
         const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
@@ -226,7 +229,7 @@ describe(`focus`, () => {
             </div>
         `
         );
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
         const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
@@ -255,7 +258,7 @@ describe(`focus`, () => {
             </div>
         `
         );
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         const firstLayerInput = expectHTMLQuery(`#firstLayerInput`);
         const lastLayerInput = expectHTMLQuery(`#lastLayerInput`);
@@ -280,7 +283,7 @@ describe(`focus`, () => {
             </div>
         `
         );
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         const layerInput = expectHTMLQuery(`#layerInput`);
 
@@ -307,7 +310,7 @@ describe(`focus`, () => {
             </div>
         `
         );
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         const layerFirstInput = expectHTMLQuery(`#layerFirstInput`);
         const layerLastInput = expectHTMLQuery(`#layerLastInput`);
@@ -345,7 +348,7 @@ describe(`focus`, () => {
             </div>
         `
         );
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         const layerXFirstInput = expectHTMLQuery(`#layerXFirstInput`);
         const layerXLastInput = expectHTMLQuery(`#layerXLastInput`);
@@ -386,11 +389,138 @@ describe(`focus`, () => {
         const layerInput = expectHTMLQuery(`#layerInput`);
         firstInertInput.addEventListener(`focus`, inertFocusHandler);
 
-        watchFocus(container);
+        watchFocus(container, createRoot());
 
         await keyboard.press(`Tab`);
 
         expect(document.activeElement, `focus first non inert input`).to.equal(layerInput);
         expect(inertFocusHandler, `inert input shouldn't get called`).callCount(0);
+    });
+
+    it(`should inform layer on focus and blur`, async () => {
+        const onFocusChange = stub();
+        const backdrop = createBackdropParts();
+        const { expectQuery, container } = testDriver.render(
+            () => `
+            <input id="rootInput" />
+            <input id="childInput" />
+        `
+        );
+        const rootLayer = createRoot();
+        const childLayer = rootLayer.createLayer({ settings: { onFocusChange } });
+        rootLayer.element.appendChild(expectQuery(`#rootInput`));
+        childLayer.element.appendChild(expectQuery(`#childInput`));
+        updateLayers(container, rootLayer, backdrop);
+
+        watchFocus(container, rootLayer);
+
+        expect(rootLayer.state.focusInside, `initial root focus`).to.equal(false);
+        expect(childLayer.state.focusInside, `initial child focus`).to.equal(false);
+
+        await click(`#childInput`);
+
+        expect(onFocusChange, `catch focus inside layer`).to.have.callCount(1);
+        expect(rootLayer.state.focusInside, `root nested focus`).to.equal(true);
+        expect(childLayer.state.focusInside, `child focus`).to.equal(true);
+
+        await click(`#rootInput`);
+
+        expect(onFocusChange, `catch blur outside layer`).to.have.callCount(2);
+        expect(rootLayer.state.focusInside, `root focus`).to.equal(true);
+        expect(childLayer.state.focusInside, `child blur`).to.equal(false);
+    });
+
+    it(`should inform parent layers`, async () => {
+        const onFocusChangeParent = stub();
+        const onFocusChangeChild = stub();
+        const backdrop = createBackdropParts();
+        const { expectQuery, container } = testDriver.render(
+            () => `
+            <input id="rootInput" />
+            <input id="parentInput" />
+            <input id="childInput" />
+        `
+        );
+        const rootLayer = createRoot();
+        const parentLayer = rootLayer.createLayer({
+            settings: { onFocusChange: onFocusChangeParent },
+        });
+        const childLayer = parentLayer.createLayer({
+            settings: { onFocusChange: onFocusChangeChild },
+        });
+        rootLayer.element.appendChild(expectQuery(`#rootInput`));
+        parentLayer.element.appendChild(expectQuery(`#parentInput`));
+        childLayer.element.appendChild(expectQuery(`#childInput`));
+        updateLayers(container, rootLayer, backdrop);
+
+        watchFocus(container, rootLayer);
+
+        expect(rootLayer.state.focusInside, `initial root focus`).to.equal(false);
+        expect(parentLayer.state.focusInside, `initial parent focus`).to.equal(false);
+        expect(childLayer.state.focusInside, `initial child focus`).to.equal(false);
+
+        await click(`#childInput`);
+
+        expect(onFocusChangeChild, `catch focus inside layer`).to.have.callCount(1);
+        expect(onFocusChangeParent, `catch focus inside parent`).to.have.callCount(1);
+        expect(childLayer.state.focusInside, `child focus`).to.equal(true);
+        expect(parentLayer.state.focusInside, `parent focus`).to.equal(true);
+        expect(rootLayer.state.focusInside, `root nested focus`).to.equal(true);
+
+        await click(`#parentInput`);
+
+        expect(onFocusChangeChild, `catch blur outside layer`).to.have.callCount(2);
+        expect(onFocusChangeParent, `no change for parent`).to.have.callCount(1);
+        expect(childLayer.state.focusInside, `child blur`).to.equal(false);
+        expect(parentLayer.state.focusInside, `parent direct focus`).to.equal(true);
+        expect(rootLayer.state.focusInside, `root still focus`).to.equal(true);
+
+        await click(`#rootInput`);
+
+        expect(onFocusChangeChild, `no change for layer`).to.have.callCount(2);
+        expect(onFocusChangeParent, `catch blur for parent`).to.have.callCount(2);
+        expect(childLayer.state.focusInside, `child still blur`).to.equal(false);
+        expect(parentLayer.state.focusInside, `parent now blur`).to.equal(false);
+        expect(rootLayer.state.focusInside, `root direct focus`).to.equal(true);
+    });
+
+    it(`should not inform common parent between nested layers`, async () => {
+        const onFocusChange = stub();
+        const backdrop = createBackdropParts();
+        const { expectQuery, container } = testDriver.render(
+            () => `
+            <input id="rootInput" />
+            <input id="parentInput" />
+            <input id="childAInput" />
+            <input id="childBInput" />
+        `
+        );
+        const rootLayer = createRoot();
+        const parentLayer = rootLayer.createLayer({
+            settings: { onFocusChange },
+        });
+        const childALayer = parentLayer.createLayer();
+        const childBLayer = parentLayer.createLayer();
+        rootLayer.element.appendChild(expectQuery(`#rootInput`));
+        parentLayer.element.appendChild(expectQuery(`#parentInput`));
+        childALayer.element.appendChild(expectQuery(`#childAInput`));
+        childBLayer.element.appendChild(expectQuery(`#childBInput`));
+        updateLayers(container, rootLayer, backdrop);
+
+        watchFocus(container, rootLayer);
+
+        await click(`#childAInput`);
+
+        expect(onFocusChange, `catch nested focus inside parent`).to.have.callCount(1);
+        expect(childALayer.state.focusInside, `focus inside layer A`).to.equal(true);
+        expect(childBLayer.state.focusInside, `focus not inside layer B`).to.equal(false);
+        expect(parentLayer.state.focusInside, `focus nested in parent`).to.equal(true);
+
+        await click(`#childBInput`);
+
+        expect(onFocusChange, `no focus change inside parent`).to.have.callCount(1);
+        expect(childALayer.state.focusInside, `focus not inside layer A`).to.equal(false);
+        expect(childBLayer.state.focusInside, `focus not inside layer B`).to.equal(true);
+        expect(parentLayer.state.focusInside, `focus still nested in parent`).to.equal(true);
     });
 });

--- a/packages/browser/test/mouse-inside.spec.ts
+++ b/packages/browser/test/mouse-inside.spec.ts
@@ -1,0 +1,242 @@
+import { watchMouseInside, createRoot, updateLayers, createBackdropParts, css } from '../src';
+import { HTMLTestDriver } from './html-test-driver';
+import { getInteractionApi } from '@zeejs/test-browser/browser';
+import chai, { expect } from 'chai';
+import { stub } from 'sinon';
+import sinonChai from 'sinon-chai';
+import { waitFor } from 'promise-assist';
+chai.use(sinonChai);
+
+describe(`mouse-inside`, () => {
+    let testDriver: HTMLTestDriver;
+    const { hover } = getInteractionApi();
+
+    before('setup test driver', () => (testDriver = new HTMLTestDriver()));
+    afterEach('clear test driver', () => testDriver.clean());
+
+    it(`should inform layer when mouse enters and leaves`, async () => {
+        const onMouseIntersection = stub();
+        const backdrop = createBackdropParts();
+        const { container, expectQuery } = testDriver.render(
+            () => `
+            <div id="root-node" style="width: 50px; height: 50px;"></div>
+            <div id="child-node" style="width: 50px; height: 50px;"></div>
+        `
+        );
+        const rootLayer = createRoot();
+        const childLayer = rootLayer.createLayer({ settings: { onMouseIntersection } });
+        rootLayer.element.appendChild(expectQuery(`#root-node`));
+        childLayer.element.appendChild(expectQuery(`#child-node`));
+        updateLayers(container, rootLayer, backdrop);
+
+        watchMouseInside(container, rootLayer, backdrop);
+
+        await hover(`#child-node`);
+
+        await waitFor(() => {
+            expect(onMouseIntersection, `catch mouse inside layer`).to.have.callCount(1);
+            expect(childLayer.state, `mouse in child layer`).to.contains({
+                mouseInside: true,
+            });
+        });
+
+        await hover(`#root-node`);
+
+        await waitFor(() => {
+            expect(onMouseIntersection, `catch mouse outside layer`).to.have.callCount(2);
+            expect(childLayer.state, `mouse out of child layer`).to.contains({
+                mouseInside: false,
+            });
+        });
+    });
+
+    it(`should inform parent layers`, async () => {
+        const onMouseIntersectionParent = stub();
+        const onMouseIntersectionChild = stub();
+        const backdrop = createBackdropParts();
+        const { container, expectQuery } = testDriver.render(
+            () => `
+            <div id="root-node" style="width: !00px; height: 100px;"></div>
+            <div id="parent-node" style="width: 50px; height: 50px;"></div>
+            <div id="child-node" style="width: 25px; height: 25px;"></div>
+        `
+        );
+        const rootLayer = createRoot();
+        const parentLayer = rootLayer.createLayer({
+            settings: { onMouseIntersection: onMouseIntersectionParent },
+        });
+        const childLayer = parentLayer.createLayer({
+            settings: { onMouseIntersection: onMouseIntersectionChild },
+        });
+        rootLayer.element.appendChild(expectQuery(`#root-node`));
+        parentLayer.element.appendChild(expectQuery(`#parent-node`));
+        childLayer.element.appendChild(expectQuery(`#child-node`));
+        updateLayers(container, rootLayer, backdrop);
+
+        watchMouseInside(container, rootLayer, backdrop);
+
+        await hover(`#child-node`);
+
+        await waitFor(() => {
+            expect(onMouseIntersectionChild, `catch mouse inside layer`).to.have.callCount(1);
+            expect(onMouseIntersectionParent, `catch mouse inside parent`).to.have.callCount(1);
+            expect(childLayer.state, `mouse in layer`).to.contains({
+                mouseInside: true,
+            });
+            expect(parentLayer.state, `mouse in parent layer`).to.contains({
+                mouseInside: true,
+            });
+            expect(rootLayer.state, `mouse in root`).to.contains({
+                mouseInside: true,
+            });
+        });
+
+        await hover(`#parent-node`);
+
+        await waitFor(() => {
+            expect(onMouseIntersectionChild, `catch mouse outside layer`).to.have.callCount(2);
+            expect(onMouseIntersectionParent, `no mouse change inside parent`).to.have.callCount(1);
+            expect(childLayer.state, `mouse in layer`).to.contains({
+                mouseInside: false,
+            });
+            expect(parentLayer.state, `mouse in parent layer`).to.contains({
+                mouseInside: true,
+            });
+            expect(rootLayer.state, `mouse in root`).to.contains({
+                mouseInside: true,
+            });
+        });
+
+        await hover(`#root-node`);
+
+        await waitFor(() => {
+            expect(onMouseIntersectionChild, `no mouse change in layer`).to.have.callCount(2);
+            expect(onMouseIntersectionParent, `catch mouse outside parent`).to.have.callCount(2);
+            expect(childLayer.state, `mouse in layer`).to.contains({
+                mouseInside: false,
+            });
+            expect(parentLayer.state, `mouse in parent layer`).to.contains({
+                mouseInside: false,
+            });
+            expect(rootLayer.state, `mouse in root`).to.contains({
+                mouseInside: true,
+            });
+        });
+    });
+
+    it(`should not inform common parent between nested layers`, async () => {
+        const onMouseIntersectionParent = stub();
+        const backdrop = createBackdropParts();
+        const { container, expectQuery } = testDriver.render(
+            () => `
+            <div id="root-node" style="width: !00px; height: 100px;"></div>
+            <div id="parent-node" style="width: 50px; height: 50px;"></div>
+            <div id="childA-node" style="width: 25px; height: 25px;"></div>
+            <div id="childB-node" style="width: 25px; height: 25px;"></div>
+        `
+        );
+        const rootLayer = createRoot();
+        const parentLayer = rootLayer.createLayer({
+            settings: { onMouseIntersection: onMouseIntersectionParent },
+        });
+        const childALayer = parentLayer.createLayer();
+        const childBLayer = parentLayer.createLayer();
+        rootLayer.element.appendChild(expectQuery(`#root-node`));
+        parentLayer.element.appendChild(expectQuery(`#parent-node`));
+        childALayer.element.appendChild(expectQuery(`#childA-node`));
+        childBLayer.element.appendChild(expectQuery(`#childB-node`));
+        updateLayers(container, rootLayer, backdrop);
+
+        watchMouseInside(container, rootLayer, backdrop);
+
+        await hover(`#childA-node`);
+
+        await waitFor(() => {
+            expect(onMouseIntersectionParent, `catch mouse inside parent`).to.have.callCount(1);
+            expect(childALayer.state, `mouse in layer A`).to.contains({
+                mouseInside: true,
+            });
+            expect(childBLayer.state, `mouse not in layer B`).to.contains({
+                mouseInside: false,
+            });
+            expect(parentLayer.state, `mouse in parent layer`).to.contains({
+                mouseInside: true,
+            });
+        });
+
+        await hover(`#childB-node`);
+
+        await waitFor(() => {
+            expect(onMouseIntersectionParent, `no mouse change inside parent`).to.have.callCount(1);
+            expect(childALayer.state, `mouse not in layer A`).to.contains({
+                mouseInside: false,
+            });
+            expect(childBLayer.state, `mouse in layer B`).to.contains({
+                mouseInside: true,
+            });
+            expect(parentLayer.state, `mouse in parent layer`).to.contains({
+                mouseInside: true,
+            });
+        });
+    });
+
+    it(`should consider backdrop as part of parent layer`, async () => {
+        const onMouseIntersectionParent = stub();
+        const onMouseIntersectionChild = stub();
+        const backdrop = createBackdropParts();
+        const { container, expectQuery } = testDriver.render(
+            () => `
+            <style id="style">${css}</style>
+            <div id="root-node" style="width: !00px; height: 100px;"></div>
+            <div id="parent-node" style="width: 50px; height: 50px;"></div>
+            <div id="child-node" style="width: 25px; height: 25px;"></div>
+            `
+        );
+        backdrop.block.id = `backdrop`;
+        const rootLayer = createRoot();
+        const parentLayer = rootLayer.createLayer({
+            settings: { onMouseIntersection: onMouseIntersectionParent },
+        });
+        const childLayer = parentLayer.createLayer({
+            settings: {
+                onMouseIntersection: onMouseIntersectionChild,
+                backdrop: `block`,
+            },
+        });
+        rootLayer.element.appendChild(expectQuery(`#root-node`));
+        rootLayer.element.appendChild(expectQuery(`#style`));
+        parentLayer.element.appendChild(expectQuery(`#parent-node`));
+        childLayer.element.appendChild(expectQuery(`#child-node`));
+        updateLayers(container, rootLayer, backdrop);
+
+        watchMouseInside(container, rootLayer, backdrop);
+
+        await hover(`#child-node`);
+
+        await waitFor(() => {
+            expect(onMouseIntersectionChild, `catch mouse inside layer`).to.have.callCount(1);
+            expect(onMouseIntersectionParent, `catch mouse inside parent`).to.have.callCount(1);
+            expect(childLayer.state, `mouse in layer`).to.contains({
+                mouseInside: true,
+            });
+            expect(parentLayer.state, `mouse in parent`).to.contains({
+                mouseInside: true,
+            });
+        });
+
+        await hover(`#backdrop`);
+
+        await waitFor(() => {
+            expect(onMouseIntersectionChild, `catch mouse change outside layer`).to.have.callCount(
+                2
+            );
+            expect(onMouseIntersectionParent, `no mouse change inside parent`).to.have.callCount(1);
+            expect(childLayer.state, `backdrop is outside of layer`).to.contains({
+                mouseInside: false,
+            });
+            expect(parentLayer.state, `backdrop is inside parent`).to.contains({
+                mouseInside: true,
+            });
+        });
+    });
+});

--- a/packages/browser/test/tooltip.spec.ts
+++ b/packages/browser/test/tooltip.spec.ts
@@ -334,7 +334,7 @@ describe(`tooltip`, () => {
                     expect(isOpen(), `close on blur`).to.equal(false);
                     expect(onToggle, `close toggle state`).to.have.calledOnceWith(false);
                 },
-                { timeout: 20 }
+                { timeout: 30 }
             );
         });
 

--- a/packages/browser/test/tooltip.spec.ts
+++ b/packages/browser/test/tooltip.spec.ts
@@ -1,0 +1,428 @@
+import { tooltip, css } from '../src';
+import { HTMLTestDriver } from './html-test-driver';
+import { getInteractionApi } from '@zeejs/test-browser/browser';
+import chai, { expect } from 'chai';
+import { stub } from 'sinon';
+import { waitFor, sleep } from 'promise-assist';
+import sinonChai from 'sinon-chai';
+chai.use(sinonChai);
+
+describe(`tooltip`, () => {
+    let testDriver: HTMLTestDriver;
+
+    const { hover } = getInteractionApi();
+
+    before('setup test driver', () => (testDriver = new HTMLTestDriver()));
+    afterEach('clear test driver', () => testDriver.clean());
+
+    describe(`open state`, () => {
+        it(`should initiate with false`, () => {
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor">button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen } = tooltip({ anchor });
+
+            expect(isOpen()).to.equal(false);
+        });
+
+        it(`should be positive on focus`, () => {
+            // focus anchor -> overlay appear
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor">button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen } = tooltip({ anchor });
+
+            anchor.focus();
+
+            expect(isOpen(), `open on focus`).to.equal(true);
+        });
+
+        it(`should be positive on mouse over`, async () => {
+            // mouse over anchor -> delay -> overlay appear
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor" style="width: 30px; height: 30px;">button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen } = tooltip({ anchor, mouseDelay: 30 });
+
+            await hover(`#anchor`);
+
+            await waitFor(() => {
+                expect(isOpen(), `open on hover`).to.equal(true);
+            });
+        });
+
+        it(`should be negative on mouse out`, async () => {
+            // mouse moves outside -> delay -> overlay disappears
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor" style="width: 30px; height: 30px;">button</button>
+                <button id="other" style="width: 30px; height: 30px;">other button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen } = tooltip({ anchor });
+            await hover(`#anchor`);
+            await waitFor(() => {
+                expect(isOpen(), `open on hover`).to.equal(true);
+            });
+
+            await hover(`#other`);
+
+            await waitFor(() => {
+                expect(isOpen(), `close on out`).to.equal(false);
+            });
+        });
+
+        it(`should be negative on mouse out (even when focused)`, async () => {
+            // mouse moves outside -> delay -> overlay disappears
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor" style="width: 30px; height: 30px;">button</button>
+                <button id="other" style="width: 30px; height: 30px;">other button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen } = tooltip({ anchor });
+            await hover(`#anchor`);
+            anchor.focus();
+            await waitFor(() => {
+                expect(isOpen(), `open on hover`).to.equal(true);
+            });
+
+            await hover(`#other`);
+
+            await waitFor(() => {
+                expect(isOpen(), `close on out`).to.equal(false);
+            });
+        });
+
+        it(`should persist on mouse out and back over`, async () => {
+            // ToDo: keep open when over overlay
+            // mouse moves outside -> delay -> mouse over anchor -> overlay persist
+            const onToggle = stub();
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor" style="width: 30px; height: 30px;">button</button>
+                <button id="other" style="width: 30px; height: 30px;">other button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen } = tooltip({ anchor, mouseDelay: 200, onToggle });
+            await hover(`#anchor`);
+            await waitFor(() => {
+                expect(isOpen(), `open on hover`).to.equal(true);
+            });
+            onToggle.reset();
+
+            await hover(`#other`);
+            await hover(`#anchor`);
+
+            await sleep(250);
+            await waitFor(() => {
+                expect(isOpen(), `keep open on back`).to.equal(true);
+                expect(onToggle, `no open state toggle`).to.have.callCount(0);
+            });
+        });
+
+        it(`should persist on mouse out and over overlay`, async () => {
+            // mouse moves outside -> delay -> mouse over overlay -> overlay persist
+            const onToggle = stub();
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor" style="width: 30px; height: 30px;">button</button>
+                <button id="other" style="width: 30px; height: 30px;">other button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen, flagMouseOverOverlay } = tooltip({ anchor, mouseDelay: 200, onToggle });
+            await hover(`#anchor`);
+            await waitFor(() => {
+                expect(isOpen(), `open on hover`).to.equal(true);
+            });
+            onToggle.reset();
+
+            await hover(`#other`);
+            flagMouseOverOverlay(true);
+
+            await sleep(250);
+            await waitFor(() => {
+                expect(isOpen(), `keep open on back`).to.equal(true);
+                expect(onToggle, `no open state toggle`).to.have.callCount(0);
+            });
+        });
+
+        it(`should be negative on mouse out of overlay`, async () => {
+            // mouse moves outside -> delay -> mouse over overlay -> mouse out of overlay -> delay -> overlay disappears
+            const onToggle = stub();
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor" style="width: 30px; height: 30px;">button</button>
+                <button id="other" style="width: 30px; height: 30px;">other button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen, flagMouseOverOverlay } = tooltip({ anchor, mouseDelay: 200, onToggle });
+            await hover(`#anchor`);
+            await waitFor(() => {
+                expect(isOpen(), `open on hover`).to.equal(true);
+            });
+            await hover(`#other`);
+            flagMouseOverOverlay(true);
+            onToggle.reset();
+
+            flagMouseOverOverlay(false);
+
+            await sleep(250);
+            await waitFor(() => {
+                expect(isOpen(), `close on out`).to.equal(false);
+                expect(onToggle, `close state on out of overlay`).to.have.callCount(1);
+            });
+        });
+
+        it(`should be negative on mouse move outside (out of anchor and overlay)`, async () => {
+            // mouse moves outside -> delay -> overlay disappears
+            const onToggle = stub();
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor" style="width: 30px; height: 30px;">button</button>
+                <button id="other" style="width: 30px; height: 30px;">other button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen } = tooltip({ anchor, onToggle });
+            anchor.focus();
+            await waitFor(() => {
+                expect(isOpen(), `open on focus`).to.equal(true);
+            });
+            onToggle.reset();
+
+            await hover(`#other`);
+
+            await waitFor(() => {
+                expect(isOpen(), `close on move outside`).to.equal(false);
+                expect(onToggle, `close state on move outside`).to.have.callCount(1);
+            });
+        });
+
+        it(`should persist on mouse out and focus`, async () => {
+            // mouse moves outside -> delay -> focus anchor -> overlay persist
+            const onToggle = stub();
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor" style="width: 30px; height: 30px;">button</button>
+                <button id="other" style="width: 30px; height: 30px;">other button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen } = tooltip({ anchor, mouseDelay: 200, onToggle });
+            await hover(`#anchor`);
+            await waitFor(() => {
+                expect(isOpen(), `open on hover`).to.equal(true);
+            });
+            onToggle.reset();
+
+            await hover(`#other`);
+            anchor.focus();
+
+            await sleep(250);
+            await waitFor(() => {
+                expect(isOpen(), `keep open on focus`).to.equal(true);
+                expect(onToggle, `no open state toggle`).to.have.callCount(0);
+            });
+        });
+
+        it(`should persist on mouse out and focus into overlay`, async () => {
+            // mouse moves outside -> delay -> focus overlay -> overlay persist
+            const onToggle = stub();
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor" style="width: 30px; height: 30px;">button</button>
+                <button id="other" style="width: 30px; height: 30px;">other button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen, flagOverlayFocus } = tooltip({ anchor, mouseDelay: 200, onToggle });
+            await hover(`#anchor`);
+            await waitFor(() => {
+                expect(isOpen(), `open on hover`).to.equal(true);
+            });
+            onToggle.reset();
+
+            await hover(`#other`);
+            flagOverlayFocus(true);
+
+            await sleep(250);
+            await waitFor(() => {
+                expect(isOpen(), `keep open on focus overlay`).to.equal(true);
+                expect(onToggle, `no open state toggle`).to.have.callCount(0);
+            });
+        });
+
+        it(`should persist on focus out into overlay`, async () => {
+            // focus out -> delay -> focus overlay -> overlay persist
+            const onToggle = stub();
+            const checkInOverlay = stub().returns(true);
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor" style="width: 30px; height: 30px;">button</button>
+                <div id="overlay" style="width: 30px; height: 30px;">
+                    <div>overlay</div>
+                    <input id="overlayInput"></input>
+                </div>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const overlay = expectHTMLQuery(`#overlay`);
+            const overlayInput = expectHTMLQuery(`#overlayInput`);
+            const { isOpen } = tooltip({
+                anchor,
+                overlay,
+                mouseDelay: 200,
+                onToggle,
+                isInOverlay: checkInOverlay,
+            });
+            anchor.focus();
+            onToggle.reset();
+
+            overlayInput.focus();
+            await waitFor(() => {
+                expect(checkInOverlay, `check focused`).to.have.been.calledOnceWith(
+                    overlayInput,
+                    overlay
+                );
+            });
+
+            await sleep(250);
+            await waitFor(() => {
+                expect(isOpen(), `keep open on overlay focus`).to.equal(true);
+                expect(onToggle, `no open state toggle`).to.have.callCount(0);
+            });
+        });
+
+        it(`should be negative on blur`, async () => {
+            // focus out -> content disappears (async delay, doesn't matter where the mouse is)
+            const onToggle = stub();
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <button id="anchor" style="width: 30px; height: 30px;">button</button>
+                <button id="other" style="width: 30px; height: 30px;">other button</button>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const { isOpen, flagMouseOverOverlay } = tooltip({ anchor, mouseDelay: 200, onToggle });
+            await hover(`#anchor`);
+            flagMouseOverOverlay(true);
+            await waitFor(() => {
+                expect(isOpen(), `open on hover`).to.equal(true);
+            });
+            anchor.focus();
+            onToggle.reset();
+
+            anchor.blur();
+
+            await waitFor(
+                () => {
+                    expect(isOpen(), `close on blur`).to.equal(false);
+                    expect(onToggle, `close toggle state`).to.have.calledOnceWith(false);
+                },
+                { timeout: 20 }
+            );
+        });
+
+        it.skip(`should be negative on escape press`, () => {
+            /*todo*/
+        });
+    });
+
+    describe(`display`, () => {
+        it(`should be hidden until overlay is open`, async () => {
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <style>
+                    ${css}
+                    #overlayInner {
+                        visibility: visible;
+                    }
+                </style>
+                <div style="height: 100vh; display: grid; align-items: center; justify-content: center;">
+                    <button id="anchor" style="width: 30px; height: 30px;">anchor</button>
+                </div>
+                <span id="overlay">
+                    <span id="overlayInner">overlay</span>
+                </span>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const overlay = expectHTMLQuery(`#overlay`);
+            const overlayInner = expectHTMLQuery(`#overlayInner`);
+
+            const { initialOverlayCSSClass } = tooltip({
+                anchor,
+                overlay,
+            });
+
+            expect(
+                overlay.classList.contains(initialOverlayCSSClass),
+                `overlay is set with initial CSS class`
+            ).to.equal(true);
+            expect(getComputedStyle(overlay).visibility, `overlay hidden before`).to.equal(
+                `hidden`
+            );
+            expect(
+                getComputedStyle(overlayInner).visibility,
+                `overlay inner hidden before`
+            ).to.equal(`hidden`);
+
+            anchor.focus();
+
+            await waitFor(() => {
+                expect(
+                    getComputedStyle(overlay).visibility,
+                    `overlay visible when opened`
+                ).to.equal(`visible`);
+                expect(
+                    getComputedStyle(overlayInner).visibility,
+                    `overlay inner visible when opened`
+                ).to.equal(`visible`);
+            });
+        });
+
+        it(`should keep position above anchor by default`, async () => {
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <div style="height: 100vh; display: grid; align-items: center; justify-content: center;">
+                    <button id="anchor" style="width: 30px; height: 30px;">anchor</button>
+                </div>
+                <span id="overlay">overlay</span>
+            `
+            );
+            const anchor = expectHTMLQuery(`#anchor`) as HTMLButtonElement;
+            const overlay = expectHTMLQuery(`#overlay`);
+
+            tooltip({
+                anchor,
+                overlay,
+            });
+
+            anchor.focus();
+
+            await waitFor(() => {
+                const anchorRect = anchor.getBoundingClientRect();
+                const overlayRect = overlay.getBoundingClientRect();
+                expect(Math.round(overlayRect.bottom), `above`).to.equal(anchorRect.top);
+                expect(Math.round(overlayRect.left + overlayRect.width / 2), `centered`).to.equal(
+                    Math.round(anchorRect.left + anchorRect.width / 2)
+                );
+            });
+        });
+    });
+});

--- a/packages/browser/test/utils.spec.ts
+++ b/packages/browser/test/utils.spec.ts
@@ -1,0 +1,107 @@
+import { isContainedBy } from '../src';
+import { HTMLTestDriver } from './html-test-driver';
+import { expect } from 'chai';
+
+describe(`utils`, () => {
+    let testDriver: HTMLTestDriver;
+
+    before('setup test driver', () => (testDriver = new HTMLTestDriver()));
+    afterEach('clear test driver', () => testDriver.clean());
+
+    describe(`isContainedBy`, () => {
+        it(`should be true for element contained under another element`, () => {
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <div id="container">
+                    <div>
+                        <div id="inner"></div>
+                    </div>
+                </div>
+            `
+            );
+            const inner = expectHTMLQuery(`#inner`);
+            const container = expectHTMLQuery(`#container`);
+
+            const isContained = isContainedBy(inner, container);
+
+            expect(isContained).to.equal(true);
+        });
+
+        it(`should be false for element not contained under another element`, () => {
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <div id="container"></div>
+                <div id="inner"></div>
+            `
+            );
+            const inner = expectHTMLQuery(`#inner`);
+            const container = expectHTMLQuery(`#container`);
+
+            const isContained = isContainedBy(inner, container);
+
+            expect(isContained).to.equal(false);
+        });
+
+        it(`should be true for element contained in a layer under container`, () => {
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <zeejs-layer>
+                    <div id="container">
+                        <zeejs-origin data-origin="layerA" tabIndex="0">
+                    </div>
+                </zeejs-layer>
+                <zeejs-layer id="layerA">
+                    <zeejs-origin data-origin="layerB" tabIndex="0">
+                </zeejs-layer>
+                <zeejs-layer id="layerB">
+                    <div>
+                        <div id="inner"></div>
+                    </div>
+                </zeejs-layer>
+            `
+            );
+            const inner = expectHTMLQuery(`#inner`);
+            const container = expectHTMLQuery(`#container`);
+
+            const isContained = isContainedBy(inner, container);
+
+            expect(isContained).to.equal(true);
+        });
+
+        it(`should be false for missing layer origin`, () => {
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <zeejs-layer>
+                    <div id="container">
+                        <zeejs-origin data-origin="layerA" tabIndex="0">
+                    </div>
+                </zeejs-layer>
+                <zeejs-layer id="layerB">
+                    <div>
+                        <div id="inner"></div>
+                    </div>
+                </zeejs-layer>
+            `
+            );
+            const inner = expectHTMLQuery(`#inner`);
+            const container = expectHTMLQuery(`#container`);
+
+            const isContained = isContainedBy(inner, container);
+
+            expect(isContained).to.equal(false);
+        });
+
+        it(`should be true when element equals contained`, () => {
+            const { expectHTMLQuery } = testDriver.render(
+                () => `
+                <div id="inner"></div>
+            `
+            );
+            const inner = expectHTMLQuery(`#inner`);
+
+            const isContained = isContainedBy(inner, inner);
+
+            expect(isContained).to.equal(true);
+        });
+    });
+});

--- a/packages/react/demo/demos/tooltip-demo.tsx
+++ b/packages/react/demo/demos/tooltip-demo.tsx
@@ -1,0 +1,96 @@
+// import { getUniqueId } from '../unique-id';
+import { Box } from '../box';
+import { Tooltip } from '@zeejs/react';
+import React from 'react';
+
+export const TooltipDemo = () => {
+    // const id = React.useMemo(() => getUniqueId(), []);
+    // const [tooltipOptions, updateOptions] = React.useState({
+    //     mouseDelay: 500,
+    // });
+
+    return (
+        <>
+            <h2 title="native title">Tooltip</h2>
+            {/* <form>
+                <label htmlFor={id + `-mouseDelay`}>mouse delay (ms)</label>
+                <input
+                    id={id + `-mouseDelay`}
+                    type="number"
+                    value={tooltipOptions.mouseDelay}
+                    onChange={({ target }) =>
+                        updateOptions((data) => ({ ...data, mouseDelay: Number(target.value) }))
+                    }
+                ></input>
+            </form> */}
+            <div
+                style={{
+                    // marginTop: `1em`,
+                    display: `flex`,
+                    justifyContent: `space-evenly`,
+                    flexWrap: `wrap`,
+                }}
+            >
+                <a href="#">
+                    link
+                    <Tooltip>
+                        <Box shadow>
+                            <Box shadow style={{ padding: `0.5em` }}>
+                                Tooltip from {`<a />`}
+                            </Box>
+                        </Box>
+                    </Tooltip>
+                </a>
+                <button>
+                    button
+                    <Tooltip>
+                        <Box shadow style={{ padding: `0.5em` }}>
+                            Tooltip from {`<button />`}
+                        </Box>
+                    </Tooltip>
+                </button>
+                <div tabIndex={0}>
+                    div with tip
+                    <Tooltip>
+                        <Box shadow style={{ maxWidth: `20em`, padding: `0.5em` }}>
+                            Don't forget to set the tooltip anchor to be tabbable for keyboard
+                            navigation
+                        </Box>
+                    </Tooltip>
+                </div>
+                <button>
+                    interactive tooltip
+                    <Tooltip>
+                        <Box
+                            shadow
+                            style={{ padding: `0.5em`, display: `grid`, justifyItems: `start` }}
+                        >
+                            <input
+                                value="click or focus into tooltip"
+                                onChange={() => {
+                                    /**/
+                                }}
+                            />
+                            <a href="#">
+                                nested tooltip
+                                <Tooltip>
+                                    <Box shadow style={{ padding: `0.5em` }}>
+                                        Tooltip from{' '}
+                                        <a href="#">
+                                            tooltip?
+                                            <Tooltip>
+                                                <Box shadow style={{ padding: `0.5em` }}>
+                                                    ...from tooltip
+                                                </Box>
+                                            </Tooltip>
+                                        </a>
+                                    </Box>
+                                </Tooltip>
+                            </a>
+                        </Box>
+                    </Tooltip>
+                </button>
+            </div>
+        </>
+    );
+};

--- a/packages/react/demo/index.tsx
+++ b/packages/react/demo/index.tsx
@@ -1,6 +1,7 @@
 import { Root } from '../src';
 import { Box } from './box';
 import { ModalDemo } from './demos/modal-demo';
+import { TooltipDemo } from './demos/tooltip-demo';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -30,7 +31,7 @@ globalCSS.innerHTML = `
         color: inherit;
         font: inherit;
         /* Normalize "line-height". Cannot be changed from "normal" in Firefox 4+. */
-        line-height: normal;    
+        line-height: normal;
         /* Corrects font smoothing for webkit */
         -webkit-font-smoothing: inherit;
         -moz-osx-font-smoothing: inherit;
@@ -40,7 +41,7 @@ globalCSS.innerHTML = `
     .resetButton[disabled] {
         cursor: default;
     }
-    
+
     :focus {
         outline: 5px solid gold;
     }
@@ -126,6 +127,8 @@ const Demos = () => {
                 <ModalDemo>
                     <Demos />
                 </ModalDemo>
+                <hr />
+                <TooltipDemo />
             </div>
         </>
     );

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,3 +1,4 @@
 export { Root } from './root';
 export { Layer } from './layer';
+export { Tooltip } from './tooltip';
 export type { LayerProps } from './layer';

--- a/packages/react/src/layer.tsx
+++ b/packages/react/src/layer.tsx
@@ -9,6 +9,7 @@ export interface LayerProps {
     overlap?: `window` | HTMLElement;
     backdrop?: `none` | `block` | `hide`;
     onClickOutside?: () => void;
+    onFocusChange?: (isFocused: boolean) => void;
 }
 
 // ToDo: handle styling on portal root
@@ -17,6 +18,7 @@ export const Layer = ({
     overlap = `window`,
     backdrop = `none`,
     onClickOutside,
+    onFocusChange,
 }: LayerProps) => {
     const parentLayer = useContext(zeejsContext);
     const layer = useMemo(
@@ -26,6 +28,11 @@ export const Layer = ({
                     overlap,
                     backdrop,
                     onClickOutside,
+                    onFocusChange: () => {
+                        if (onFocusChange) {
+                            onFocusChange(layer.state.focusInside);
+                        }
+                    },
                 },
             }),
         []

--- a/packages/react/src/layer.tsx
+++ b/packages/react/src/layer.tsx
@@ -9,6 +9,7 @@ export interface LayerProps {
     overlap?: `window` | HTMLElement;
     backdrop?: `none` | `block` | `hide`;
     onClickOutside?: () => void;
+    onMouseIntersection?: (isInside: boolean) => void;
     onFocusChange?: (isFocused: boolean) => void;
 }
 
@@ -18,6 +19,7 @@ export const Layer = ({
     overlap = `window`,
     backdrop = `none`,
     onClickOutside,
+    onMouseIntersection,
     onFocusChange,
 }: LayerProps) => {
     const parentLayer = useContext(zeejsContext);
@@ -28,6 +30,11 @@ export const Layer = ({
                     overlap,
                     backdrop,
                     onClickOutside,
+                    onMouseIntersection: () => {
+                        if (onMouseIntersection) {
+                            onMouseIntersection(layer.state.mouseInside);
+                        }
+                    },
                     onFocusChange: () => {
                         if (onFocusChange) {
                             onFocusChange(layer.state.focusInside);

--- a/packages/react/src/root.tsx
+++ b/packages/react/src/root.tsx
@@ -52,7 +52,7 @@ export const Root = ({ className, style, children }: RootProps) => {
         const wrapper = rootRef.current!;
         document.head.appendChild(parts.style);
         rootLayer.element = wrapper.firstElementChild! as HTMLElement;
-        const { stop: stopFocus } = watchFocus(wrapper);
+        const { stop: stopFocus } = watchFocus(wrapper, rootLayer);
         const { stop: stopClickOutside } = watchClickOutside(wrapper, rootLayer, parts);
         updateLayers(wrapper, rootLayer, parts);
         () => {

--- a/packages/react/src/root.tsx
+++ b/packages/react/src/root.tsx
@@ -1,6 +1,7 @@
 import {
     watchFocus,
     watchClickOutside,
+    watchMouseInside,
     createRoot,
     DOMLayer,
     updateLayers,
@@ -54,11 +55,14 @@ export const Root = ({ className, style, children }: RootProps) => {
         rootLayer.element = wrapper.firstElementChild! as HTMLElement;
         const { stop: stopFocus } = watchFocus(wrapper, rootLayer);
         const { stop: stopClickOutside } = watchClickOutside(wrapper, rootLayer, parts);
+        const { stop: stopMouseInside } = watchMouseInside(wrapper, rootLayer, parts);
         updateLayers(wrapper, rootLayer, parts);
         () => {
+            // ToDo: check why not removed in tests
             document.head.removeChild(parts.style);
             stopFocus();
             stopClickOutside();
+            stopMouseInside();
         };
     }, []);
 

--- a/packages/react/src/tooltip.tsx
+++ b/packages/react/src/tooltip.tsx
@@ -1,0 +1,52 @@
+import { Layer } from './layer';
+import { tooltip, isContainedBy } from '@zeejs/browser';
+import React, { ReactNode, useMemo, useEffect, useState, useRef } from 'react';
+
+export interface TooltipProps {
+    children: ReactNode;
+    mouseDelay?: number;
+}
+
+export const Tooltip = ({ children, mouseDelay }: TooltipProps) => {
+    const [isOpen, onToggle] = useState(false);
+    const tooltipLogic = useMemo(
+        () =>
+            tooltip({
+                onToggle,
+                mouseDelay,
+                isInOverlay: isContainedBy,
+            }),
+        []
+    );
+    const placeholderRef = useRef<HTMLSpanElement>(null);
+    const overlayRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const anchor = placeholderRef.current?.parentElement;
+        if (!anchor) {
+            return;
+        }
+        tooltipLogic.setAnchor(anchor);
+        return () => tooltipLogic.stop();
+    }, []);
+
+    useEffect(() => {
+        tooltipLogic.setOverlay(overlayRef.current);
+    }, [isOpen, overlayRef.current]);
+
+    return (
+        <span ref={placeholderRef}>
+            {isOpen ? (
+                <Layer
+                    onFocusChange={tooltipLogic.flagOverlayFocus}
+                    onMouseIntersection={tooltipLogic.flagMouseOverOverlay}
+                    onClickOutside={() => tooltipLogic.flagOverlayFocus(false)}
+                >
+                    <div ref={overlayRef} className={tooltipLogic.initialOverlayCSSClass}>
+                        {children}
+                    </div>
+                </Layer>
+            ) : null}
+        </span>
+    );
+};

--- a/packages/react/test/root-and-layer.spec.tsx
+++ b/packages/react/test/root-and-layer.spec.tsx
@@ -1,52 +1,43 @@
-import * as zeejsSvelte from '../src';
+import { Root, Layer } from '../src';
 import { domElementMatchers } from './chai-dom-element';
-import RenderRootServerFixture from './server-fixtures/RenderRoot.svelte';
-import RenderLayerServerFixture from './server-fixtures/RenderLayer.svelte';
-import { SvelteTestDriver } from './svelte-test-driver';
+import { ReactTestDriver } from './react-test-driver';
 import {
     expectImageSnapshot,
     getInteractionApi,
     expectServerFixture,
 } from '@zeejs/test-browser/browser';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import { waitFor } from 'promise-assist';
 import chai, { expect } from 'chai';
 import sinon, { stub, spy } from 'sinon';
 import sinonChai from 'sinon-chai';
+import { act } from 'react-dom/test-utils';
 chai.use(sinonChai);
 chai.use(domElementMatchers);
 
-describe(`svelte`, () => {
-    let testDriver: SvelteTestDriver;
+describe(`root-and-layer`, () => {
+    let testDriver: ReactTestDriver;
     const { click, clickIfPossible, keyboard, hover } = getInteractionApi();
 
-    before('setup test driver', () => {
-        testDriver = new SvelteTestDriver({
-            '@zeejs/svelte': zeejsSvelte,
-        });
-    });
+    before('setup test driver', () => (testDriver = new ReactTestDriver()));
     afterEach('clear test driver', () => {
         testDriver.clean();
         sinon.restore();
     });
 
     it(`should render main layer`, () => {
-        const { container } = testDriver.render(`
-            <script>
-                import {Root} from '@zeejs/svelte';
-            </script>
+        const { container } = testDriver.render(() => (
             <Root>
                 <div>content</div>
             </Root>
-        `);
+        ));
 
         expect(container.textContent).to.equal(`content`);
     });
 
     it(`should position layer after main layer in DOM`, () => {
-        const { expectQuery } = testDriver.render(`
-            <script>
-                import {Root, Layer} from '@zeejs/svelte';
-            </script>
+        const { expectQuery } = testDriver.render(() => (
             <Root>
                 <div id="root-node">
                     <Layer>
@@ -54,7 +45,7 @@ describe(`svelte`, () => {
                     </Layer>
                 </div>
             </Root>
-        `);
+        ));
 
         const rootNode = expectQuery(`#root-node`);
         const layerNode = expectQuery(`#layer-node`);
@@ -62,81 +53,84 @@ describe(`svelte`, () => {
         expect(rootNode, `layer after root`).domElement().preceding(layerNode);
     });
 
-    it(`should render layer after initial render`, async () => {
-        const { expectQuery, query, updateProps } = testDriver.render(`
-            <script>
-                import {Root, Layer} from '@zeejs/svelte';
-                export let renderLayer = false;
-            </script>
-            <Root>
-                <div id="root-node">
-                    {#if renderLayer}
-                        <Layer>
-                            <div id="layer-node" />
-                        </Layer>
-                    {/if}
-                </div>
-            </Root>
-        `);
+    it(`should render layer after initial render`, () => {
+        const { expectQuery, query, setData } = testDriver.render<boolean>(
+            (renderLayer) => (
+                <Root>
+                    <div id="root-node">
+                        {renderLayer ? (
+                            <Layer>
+                                <div id="layer-node" />
+                            </Layer>
+                        ) : null}
+                    </div>
+                </Root>
+            ),
+            {
+                initialData: false,
+            }
+        );
 
         expect(query(`#layer-node`), `before layer render`).to.not.be.domElement();
 
-        await updateProps({ renderLayer: true });
+        setData(true);
 
         const rootNode = expectQuery(`#root-node`);
         const layerNode = expectQuery(`#layer-node`);
         expect(rootNode).domElement().preceding(layerNode);
     });
 
-    it(`should remove layer`, async () => {
-        const { container, updateProps } = testDriver.render(`
-            <script>
-                import {Root, Layer} from '@zeejs/svelte';
-                export let renderLayer = true;
-            </script>
+    it(`should remove layer`, () => {
+        const { container } = testDriver.render(() => (
             <Root>
                 <div id="root-node">
-                    {#if renderLayer}
-                        <Layer>
-                            <div id="layer-node" />
-                        </Layer>
-                    {/if}
+                    <Layer>
+                        <div id="layer-node" />
+                    </Layer>
                 </div>
             </Root>
-        `);
+        ));
 
-        await updateProps({ renderLayer: false });
+        testDriver.render(
+            () => (
+                <Root>
+                    <div id="root-node" />
+                </Root>
+            ),
+            { container }
+        );
 
         const layerNode = container.querySelector(`#layer-node`);
         expect(layerNode, `layer not rendered`).to.equal(null);
         expect(container.firstElementChild?.childElementCount, `only root content`).to.equal(1);
     });
 
-    it(`should render and remove deep nested layer`, async () => {
-        const { updateProps, query, expectQuery } = testDriver.render(`
-            <script>
-                import {Root, Layer} from '@zeejs/svelte';
-                export let renderLayer = false;
-            </script>
-            <Root>
-                <div id="main">
-                    <Layer>
-                        <div id="shallow">
-                            {#if renderLayer}
-                                <Layer>
-                                    <div id="deep" />
-                                </Layer>
-                            {/if}
-                        </div>
-                    </Layer>
-                </div>
-            </Root>
-        `);
+    it(`should render and remove deep nested layer`, () => {
+        const { expectQuery, query, setData } = testDriver.render<boolean>(
+            (renderLayer) => (
+                <Root>
+                    <div id="main">
+                        <Layer>
+                            <div id="shallow">
+                                {renderLayer ? (
+                                    <Layer>
+                                        <div id="deep" />
+                                    </Layer>
+                                ) : null}
+                            </div>
+                        </Layer>
+                    </div>
+                </Root>
+            ),
+            {
+                initialData: false,
+            }
+        );
 
         expect(query(`#deep`), `not rendered`).to.not.be.domElement();
 
         // render deep layer
-        await updateProps({ renderLayer: true });
+        setData(true);
 
         const mainNode = expectQuery(`#main`);
         const shallowNode = expectQuery(`#shallow`);
@@ -145,28 +139,28 @@ describe(`svelte`, () => {
         expect(shallowNode, `shallow before deep`).domElement().preceding(deepNode);
 
         // render without deep layer
-        await updateProps({ renderLayer: false });
+        setData(false);
 
         expect(query(`#deep`), `not rendered`).to.not.be.domElement();
     });
 
     it(`should place layer relative to window (default)`, () => {
         const { innerWidth, innerHeight } = window;
-        const { expectQuery } = testDriver.render(`
-            <script>
-                import {Root, Layer} from '@zeejs/svelte';
-            </script>
+        const { expectQuery } = testDriver.render(() => (
             <Root>
                 <div
                     id="root-node"
-                    style="height: 200vh; width: 200vw;"
+                    style={{
+                        height: innerHeight * 2,
+                        width: innerWidth * 2,
+                    }}
                 >
                     <Layer>
-                        <div id="layer-node" style="width: 100%; height: 100%;" />
+                        <div id="layer-node" style={{ width: `100%`, height: `100%` }} />
                     </Layer>
                 </div>
             </Root>
-        `);
+        ));
 
         window.scrollTo(innerWidth, innerHeight);
 
@@ -179,45 +173,66 @@ describe(`svelte`, () => {
         });
     });
 
-    it(`should place layer relative to element`, () => {
+    it(`should place layer relative to element`, async () => {
         const { innerWidth, innerHeight } = window;
-        const { expectHTMLQuery } = testDriver.render(`
-            <script>
-                import {Root, Layer} from '@zeejs/svelte';
-                let relativeNode;
-            </script>
+        const { expectHTMLQuery, container } = testDriver.render(() => (
             <Root>
                 <div
                     id="root-node"
-                    style="height: 200vh; width: 200vw;"
+                    style={{
+                        height: innerHeight * 2,
+                        width: innerWidth * 2,
+                    }}
                 >
                     <div
-                        bind:this={relativeNode}
                         id="relative-node"
-                        style="width: 200px; height: 100px; margin: 30px;"
+                        style={{
+                            width: `200px`,
+                            height: `100px`,
+                            margin: `30px`,
+                        }}
                     />
-                    {#if relativeNode}
-                        <Layer overlap={relativeNode}>
-                            <div id="layer-node" style="width: 100%; height: 100%;" />
-                        </Layer>
-                    {/if}
                 </div>
             </Root>
-        `);
+        ));
         const relativeNode = expectHTMLQuery(`#relative-node`);
 
+        testDriver.render(
+            () => (
+                <Root>
+                    <div
+                        id="root-node"
+                        style={{
+                            height: innerHeight * 2,
+                            width: innerWidth * 2,
+                        }}
+                    >
+                        <div
+                            id="relative-node"
+                            style={{
+                                width: `200px`,
+                                height: `100px`,
+                                margin: `30px`,
+                            }}
+                        />
+                        <Layer overlap={relativeNode}>
+                            <div id="layer-node" style={{ width: `100%`, height: `100%` }} />
+                        </Layer>
+                    </div>
+                </Root>
+            ),
+            { container }
+        );
         window.scrollTo(innerWidth, innerHeight);
 
         const layerNode = expectHTMLQuery(`#layer-node`);
-        expect(layerNode.getBoundingClientRect()).to.eql(relativeNode.getBoundingClientRect());
+        await waitFor(() => {
+            expect(layerNode.getBoundingClientRect()).to.eql(relativeNode.getBoundingClientRect());
+        });
     });
 
     it(`should hide layer component placeholder inline`, () => {
-        const { expectQuery } = testDriver.render(`
-            <script>
-                import {Root, Layer} from '@zeejs/svelte';
-                let relativeNode;
-            </script>
+        const { expectQuery } = testDriver.render(() => (
             <Root>
                 <div id="root-node">
                     <span id="before">before</span>
@@ -227,7 +242,7 @@ describe(`svelte`, () => {
                     <span id="after">after</span>
                 </div>
             </Root>
-        `);
+        ));
 
         const before = expectQuery(`#before`);
         const layerPlaceholder = before.nextElementSibling!;
@@ -253,25 +268,18 @@ describe(`svelte`, () => {
     describe(`backdrop`, () => {
         it(`should click through backdrop by default (backdrop="none")`, async () => {
             const contentClick = stub();
-            testDriver.render(
-                `
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                    export let contentClick;
-                </script>
+            testDriver.render(() => (
                 <Root>
                     <div
                         id="back-item"
-                        on:click={contentClick}
-                        style="width: 400px; height: 400px;"
+                        onClick={() => contentClick()}
+                        style={{ width: `400px`, height: `400px` }}
                     />
                     <Layer>
                         <span />
                     </Layer>
                 </Root>
-            `,
-                { contentClick }
-            );
+            ));
 
             await click(`#back-item`);
 
@@ -280,25 +288,18 @@ describe(`svelte`, () => {
 
         it(`should prevent clicks through "block" backdrop`, async () => {
             const contentClick = stub();
-            testDriver.render(
-                `
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                    export let contentClick;
-                </script>
+            testDriver.render(() => (
                 <Root>
                     <div
                         id="back-item"
-                        on:click={contentClick}
-                        style="width: 400px; height: 400px;"
+                        onClick={() => contentClick()}
+                        style={{ width: `400px`, height: `400px` }}
                     />
                     <Layer backdrop="block">
                         <span />
                     </Layer>
                 </Root>
-            `,
-                { contentClick }
-            );
+            ));
 
             expect(await clickIfPossible(`#back-item`), `not clickable`).to.equal(false);
             expect(contentClick).to.have.callCount(0);
@@ -306,27 +307,20 @@ describe(`svelte`, () => {
 
         it(`should prevent clicks on other layers through "block" backdrop`, async () => {
             const contentClick = stub();
-            testDriver.render(
-                `
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                    export let contentClick;
-                </script>
+            testDriver.render(() => (
                 <Root>
                     <Layer backdrop="block">
                         <div
                             id="layer-item"
-                            on:click={contentClick}
-                            style="width: 400px; height: 400px;"
+                            onClick={() => contentClick()}
+                            style={{ width: `400px`, height: `400px` }}
                         />
                     </Layer>
                     <Layer backdrop="block">
                         <span />
                     </Layer>
                 </Root>
-            `,
-                { contentClick }
-            );
+            ));
 
             expect(await clickIfPossible(`#layer-item`), `not clickable`).to.equal(false);
             expect(contentClick).to.have.callCount(0);
@@ -334,27 +328,20 @@ describe(`svelte`, () => {
 
         it(`should click through to other layers with "none" backdrop (default)`, async () => {
             const contentClick = stub();
-            testDriver.render(
-                `
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                    export let contentClick;
-                </script>
+            testDriver.render(() => (
                 <Root>
                     <Layer backdrop="block">
                         <div
                             id="layer-item"
-                            on:click={contentClick}
-                            style="width: 400px; height: 400px;"
+                            onClick={() => contentClick()}
+                            style={{ width: `400px`, height: `400px` }}
                         />
                     </Layer>
                     <Layer backdrop="none">
                         <span />
                     </Layer>
                 </Root>
-            `,
-                { contentClick }
-            );
+            ));
 
             await click(`#layer-item`);
 
@@ -363,27 +350,28 @@ describe(`svelte`, () => {
 
         it(`should hide content behind layer (backdrop="hide")`, async () => {
             const contentClick = stub();
-            testDriver.render(
-                `
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                    export let contentClick;
-                </script>
+            testDriver.render(() => (
                 <Root>
                     <div
                         id="back-item"
-                        on:click={contentClick}
-                        style="width: 400px; height: 400px; background: green;"
+                        onClick={() => contentClick()}
+                        style={{
+                            width: `400px`,
+                            height: `400px`,
+                            background: `green`,
+                        }}
                     />
                     <Layer backdrop="hide">
                         <div
-                            style="width: 200px; height: 200px; background: green;"
+                            style={{
+                                width: `200px`,
+                                height: `200px`,
+                                background: `green`,
+                            }}
                         />
                     </Layer>
                 </Root>
-            `,
-                { contentClick }
-            );
+            ));
 
             expect(await clickIfPossible(`#back-item`), `not clickable`).to.equal(false);
 
@@ -394,26 +382,37 @@ describe(`svelte`, () => {
         });
 
         it(`should hide content between layers (backdrop="hide")`, async () => {
-            testDriver.render(`
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                </script>
+            testDriver.render(() => (
                 <Root>
                     <div
-                        style="width: 400px; height: 400px; background: green;"
+                        style={{
+                            width: `400px`,
+                            height: `400px`,
+                            background: `green`,
+                        }}
                     />
                     <Layer backdrop="hide">
                         <div
-                            style="width: 200px; height: 200px; position: absolute; right: 0; background: green;"
+                            style={{
+                                width: `200px`,
+                                height: `200px`,
+                                position: `absolute`,
+                                right: 0,
+                                background: `green`,
+                            }}
                         />
                     </Layer>
                     <Layer backdrop="hide">
                         <div
-                            style="width: 100px; height: 100px; background: green;"
+                            style={{
+                                width: `100px`,
+                                height: `100px`,
+                                background: `green`,
+                            }}
                         />
                     </Layer>
                 </Root>
-            `);
+            ));
 
             await expectImageSnapshot({
                 filePath: `backdrop/should hide content between layer (backdrop=hide)`,
@@ -423,10 +422,7 @@ describe(`svelte`, () => {
 
     describe(`focus`, () => {
         it(`should keep layer as part of tab order`, async () => {
-            const { expectHTMLQuery } = testDriver.render(`
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                </script>
+            const { expectHTMLQuery } = testDriver.render<boolean>(() => (
                 <Root>
                     <input id="bgBeforeInput" />
                     <Layer>
@@ -434,7 +430,7 @@ describe(`svelte`, () => {
                     </Layer>
                     <input id="bgAfterInput" />
                 </Root>
-            `);
+            ));
             const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
             const layerInput = expectHTMLQuery(`#layerInput`);
             const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
@@ -450,10 +446,7 @@ describe(`svelte`, () => {
         });
 
         it(`should trap focus in blocking layer`, async () => {
-            const { expectHTMLQuery } = testDriver.render(`
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                </script>
+            const { expectHTMLQuery } = testDriver.render<boolean>(() => (
                 <Root>
                     <input id="bgBeforeInput" />
                     <Layer backdrop="block">
@@ -462,7 +455,7 @@ describe(`svelte`, () => {
                     </Layer>
                     <input id="bgAfterInput" />
                 </Root>
-            `);
+            ));
             const layerFirstInput = expectHTMLQuery(`#layerFirstInput`);
             const layerLastInput = expectHTMLQuery(`#layerLastInput`);
 
@@ -474,48 +467,47 @@ describe(`svelte`, () => {
         });
 
         it(`should re-focus last element of an un-blocked layer`, async () => {
-            const { expectHTMLQuery, updateProps } = testDriver.render(`
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                    export let renderLayer = false;
-                </script>
-                <Root>
-                    <input id="bgInput" />
-                    {#if renderLayer}
-                        <Layer backdrop="block">layer content</Layer>
-                    {/if}
-                </Root>
-            `);
+            const warnSpy = spy(console, `warn`);
+            const errorSpy = spy(console, `error`);
+            const { expectHTMLQuery, setData } = testDriver.render<boolean>(
+                (renderLayer) => (
+                    <Root>
+                        <input id="bgInput" />
+                        {renderLayer ? <Layer backdrop="block">layer content</Layer> : null}
+                    </Root>
+                ),
+                { initialData: false }
+            );
             const bgInput = expectHTMLQuery(`#bgInput`);
             bgInput.focus();
 
-            await updateProps({ renderLayer: true });
+            setData(true);
 
-            expect(document.activeElement, `blocked input blur`).to.equal(document.body);
+            await waitFor(() => {
+                expect(document.activeElement, `blocked input blur`).to.equal(document.body);
+            });
 
-            await updateProps({ renderLayer: false });
+            setData(false);
 
-            expect(document.activeElement, `refocus input`).to.equal(bgInput);
+            await waitFor(() => {
+                expect(document.activeElement, `refocus input`).to.equal(bgInput);
+            });
+            /* blur/re-focus is delayed because React listens for blur of rendered elements during render.
+            just check that no logs have been called. */
+            expect(warnSpy, `no react warning`).to.have.callCount(0);
+            expect(errorSpy, `no react error`).to.have.callCount(0);
         });
 
         it(`should report on focus change`, async () => {
             const onFocusChange = stub();
-            testDriver.render(
-                `
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                    export let onFocusChange;
-                </script>
+            testDriver.render(() => (
                 <Root>
                     <input id="root-input" />
                     <Layer onFocusChange={onFocusChange}>
-                        <input id="layer-input" style="margin: 1em;" />
+                        <input id="layer-input" style={{ margin: `1em` }} />
                     </Layer>
                 </Root>
-                         />
-            `,
-                { onFocusChange }
-            );
+            ));
 
             await click(`#layer-input`);
 
@@ -531,22 +523,21 @@ describe(`svelte`, () => {
     describe(`click outside`, () => {
         it(`should invoke onClickOutside handler for click on root`, async () => {
             const onClickOutside = stub();
-            testDriver.render(
-                `
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                    export let onClickOutside;
-                </script>
+            testDriver.render(() => (
                 <Root>
-                    <div id="root-node" style="width: 100px; height: 100px; background: green;">
+                    <div
+                        id="root-node"
+                        style={{ width: `100px`, height: `100px`, background: `green` }}
+                    >
                         <Layer onClickOutside={onClickOutside}>
-                            <div id="layer-node" style="width: 50px; height: 50px; background: red;" />
+                            <div
+                                id="layer-node"
+                                style={{ width: `50px`, height: `50px`, background: `red` }}
+                            />
                         </Layer>
                     </div>
                 </Root>
-            `,
-                { onClickOutside }
-            );
+            ));
 
             await click(`#root-node`);
 
@@ -559,25 +550,27 @@ describe(`svelte`, () => {
 
         it(`should not invoke onClickOutside handler for nested layer click`, async () => {
             const onClickOutside = stub();
-            testDriver.render(
-                `
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                    export let onClickOutside;
-                </script>
+            testDriver.render(() => (
                 <Root>
-                    <div id="root-node" style="width: 100px; height: 100px; background: green;">
+                    <div
+                        id="root-node"
+                        style={{ width: `100px`, height: `100px`, background: `green` }}
+                    >
                         <Layer onClickOutside={onClickOutside}>
-                            <div id="shallow-node" style="width: 50px; height: 50px; background: orange;" />
+                            <div
+                                id="shallow-node"
+                                style={{ width: `50px`, height: `50px`, background: `orange` }}
+                            />
                             <Layer>
-                                <div id="deep-node" style="width: 25px; height: 25px; background: red;" />
+                                <div
+                                    id="deep-node"
+                                    style={{ width: `25px`, height: `25px`, background: `red` }}
+                                />
                             </Layer>
                         </Layer>
                     </div>
                 </Root>
-            `,
-                { onClickOutside }
-            );
+            ));
 
             await click(`#deep-node`);
 
@@ -588,22 +581,21 @@ describe(`svelte`, () => {
     describe(`mouse inside`, () => {
         it(`should inform layer when mouse enters and leaves`, async () => {
             const onMouseIntersection = stub();
-            testDriver.render(
-                `
-                <script>
-                    import {Root, Layer} from '@zeejs/svelte';
-                    export let onMouseIntersection;
-                </script>
+            testDriver.render(() => (
                 <Root>
-                    <div id="root-node" style="width: 100px; height: 100px; background: green;">
+                    <div
+                        id="root-node"
+                        style={{ width: `100px`, height: `100px`, background: `green` }}
+                    >
                         <Layer onMouseIntersection={onMouseIntersection}>
-                            <div id="layer-node" style="width: 50px; height: 50px; background: red;" />
+                            <div
+                                id="layer-node"
+                                style={{ width: `50px`, height: `50px`, background: `red` }}
+                            />
                         </Layer>
                     </div>
                 </Root>
-            `,
-                { onMouseIntersection }
-            );
+            ));
 
             await hover(`#layer-node`);
 
@@ -627,22 +619,20 @@ describe(`svelte`, () => {
             const warnSpy = spy(console, `warn`);
             const errorSpy = spy(console, `error`);
             const container = document.createElement(`div`);
+            document.body.appendChild(container);
 
-            // ToDo: test CSS once figured out how best to deliver it...
-            const { html } = await expectServerFixture({
-                fixtureFileName: `server-render.ts`,
-                exportName: `renderRoot`,
-            });
-            container.innerHTML = html;
-
-            new RenderRootServerFixture({
-                target: container,
-                hydrate: true,
+            container.innerHTML = await expectServerFixture({
+                fixtureFileName: `render-root.tsx`,
             });
 
-            expect(container.textContent?.trim()).to.equal(`content`);
-            expect(warnSpy, `no svelte warning`).to.have.callCount(0);
-            expect(errorSpy, `no svelte error`).to.have.callCount(0);
+            act(() => {
+                ReactDOM.hydrate(<Root>content</Root>, container);
+            });
+
+            expect(container.textContent).to.equal(`content`);
+            expect(warnSpy, `no react warning`).to.have.callCount(0);
+            expect(errorSpy, `no react error`).to.have.callCount(0);
+            document.body.removeChild(container);
         });
 
         it(`should render layers nested and flattened in browser`, async () => {
@@ -651,24 +641,32 @@ describe(`svelte`, () => {
             const container = document.createElement(`div`);
             document.body.appendChild(container);
 
-            const { html } = await expectServerFixture({
-                fixtureFileName: `server-render.ts`,
-                exportName: `renderLayer`,
+            container.innerHTML = await expectServerFixture({
+                fixtureFileName: `render-layer.tsx`,
             });
-            container.innerHTML = html;
 
-            const rootNode = testDriver.expectHTMLQuery(container, `#root-node`);
-            const layerNode = testDriver.expectHTMLQuery(container, `#layer-node`);
+            let rootNode = testDriver.expectHTMLQuery(container, `#root-node`);
+            let layerNode = testDriver.expectHTMLQuery(container, `#layer-node`);
             expect(rootNode, `root exist in string`).domElement();
             expect(rootNode, `layer inside root before client render`)
                 .domElement()
                 .contains(layerNode);
 
-            new RenderLayerServerFixture({
-                target: container,
-                hydrate: true,
+            act(() => {
+                ReactDOM.hydrate(
+                    <Root>
+                        <div id="root-node">
+                            <Layer>
+                                <div id="layer-node" />
+                            </Layer>
+                        </div>
+                    </Root>,
+                    container
+                );
             });
 
+            rootNode = testDriver.expectHTMLQuery(container, `#root-node`);
+            layerNode = testDriver.expectHTMLQuery(container, `#layer-node`);
             expect(layerNode, `layer exist after client render`).domElement();
             expect(rootNode, `layer after root`).domElement().preceding(layerNode);
             expect(warnSpy, `no react warning`).to.have.callCount(0);

--- a/packages/react/test/test.spec.tsx
+++ b/packages/react/test/test.spec.tsx
@@ -495,6 +495,27 @@ describe(`react`, () => {
             expect(warnSpy, `no react warning`).to.have.callCount(0);
             expect(errorSpy, `no react error`).to.have.callCount(0);
         });
+
+        it(`should report on focus change`, async () => {
+            const onFocusChange = stub();
+            testDriver.render(() => (
+                <Root>
+                    <input id="root-input" />
+                    <Layer onFocusChange={onFocusChange}>
+                        <input id="layer-input" style={{ margin: `1em` }} />
+                    </Layer>
+                </Root>
+            ));
+
+            await click(`#layer-input`);
+
+            expect(onFocusChange, `focus in layer`).to.have.been.calledOnceWith(true);
+            onFocusChange.reset();
+
+            await click(`#root-input`);
+
+            expect(onFocusChange, `focus out of layer`).to.have.been.calledOnceWith(false);
+        });
     });
 
     describe(`click outside`, () => {

--- a/packages/react/test/test.spec.tsx
+++ b/packages/react/test/test.spec.tsx
@@ -18,7 +18,7 @@ chai.use(domElementMatchers);
 
 describe(`react`, () => {
     let testDriver: ReactTestDriver;
-    const { click, clickIfPossible, keyboard } = getInteractionApi();
+    const { click, clickIfPossible, keyboard, hover } = getInteractionApi();
 
     before('setup test driver', () => (testDriver = new ReactTestDriver()));
     afterEach('clear test driver', () => {
@@ -573,6 +573,42 @@ describe(`react`, () => {
             await click(`#deep-node`);
 
             expect(onClickOutside, `no invocation for nested click`).to.have.callCount(0);
+        });
+    });
+
+    describe(`mouse inside`, () => {
+        it(`should inform layer when mouse enters and leaves`, async () => {
+            const onMouseIntersection = stub();
+            testDriver.render(() => (
+                <Root>
+                    <div
+                        id="root-node"
+                        style={{ width: `100px`, height: `100px`, background: `green` }}
+                    >
+                        <Layer onMouseIntersection={onMouseIntersection}>
+                            <div
+                                id="layer-node"
+                                style={{ width: `50px`, height: `50px`, background: `red` }}
+                            />
+                        </Layer>
+                    </div>
+                </Root>
+            ));
+
+            await hover(`#layer-node`);
+
+            await waitFor(() => {
+                expect(onMouseIntersection, `catch mouse inside layer`).to.have.callCount(1);
+                expect(onMouseIntersection, `called with true`).to.have.been.calledWith(true);
+            });
+            onMouseIntersection.reset();
+
+            await hover(`#root-node`);
+
+            await waitFor(() => {
+                expect(onMouseIntersection, `catch mouse outside layer`).to.have.callCount(1);
+                expect(onMouseIntersection, `called with false`).to.have.been.calledWith(false);
+            });
         });
     });
 

--- a/packages/react/test/tooltip.spec.tsx
+++ b/packages/react/test/tooltip.spec.tsx
@@ -1,0 +1,271 @@
+import { Root, Tooltip } from '../src';
+import { domElementMatchers } from './chai-dom-element';
+import { ReactTestDriver } from './react-test-driver';
+import { getInteractionApi } from '@zeejs/test-browser/browser';
+import React from 'react';
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { waitFor, sleep } from 'promise-assist';
+chai.use(sinonChai);
+chai.use(domElementMatchers);
+
+describe(`react tooltip`, () => {
+    let testDriver: ReactTestDriver;
+    const { hover } = getInteractionApi();
+
+    before('setup test driver', () => (testDriver = new ReactTestDriver()));
+    afterEach('clear test driver', () => {
+        testDriver.clean();
+        sinon.restore();
+    });
+
+    describe(`open state`, () => {
+        it(`should show tooltip on parent element hover & hide on out (default 0.5s delay)`, async () => {
+            const { expectQuery, query } = testDriver.render(() => (
+                <Root>
+                    <div id="other-node" style={{ padding: `100px` }}>
+                        other node content
+                    </div>
+                    <div id="parent-node">
+                        <span>parent content</span>
+                        <Tooltip>
+                            <span id="tooltip-node">tooltip content</span>
+                        </Tooltip>
+                    </div>
+                </Root>
+            ));
+
+            expect(query(`#tooltip-node`), `before hover`).to.not.be.domElement();
+
+            await hover(`#parent-node`);
+
+            await waitFor(() => {
+                const parentNode = expectQuery(`#parent-node`);
+                const tooltipNode = expectQuery(`#tooltip-node`);
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+
+            await hover(`#other-node`);
+
+            await waitFor(() => {
+                expect(query(`#tooltip-node`), `hover out`).to.not.be.domElement();
+            });
+        });
+
+        it(`should show tooltip on parent element hover & hide on out with custom mouse delay`, async () => {
+            const { expectQuery, query } = testDriver.render(() => (
+                <Root>
+                    <div id="other-node" style={{ padding: `100px` }}>
+                        other node content
+                    </div>
+                    <div id="parent-node">
+                        <span>parent content</span>
+                        <Tooltip mouseDelay={10}>
+                            <span id="tooltip-node">tooltip content</span>
+                        </Tooltip>
+                    </div>
+                </Root>
+            ));
+
+            expect(query(`#tooltip-node`), `before hover`).to.not.be.domElement();
+
+            await hover(`#parent-node`);
+
+            // should be ready before hover is returned
+            await waitFor(
+                () => {
+                    const parentNode = expectQuery(`#parent-node`);
+                    const tooltipNode = expectQuery(`#tooltip-node`);
+                    expect(parentNode).domElement().preceding(tooltipNode);
+                },
+                { timeout: 50 }
+            );
+
+            await hover(`#other-node`);
+
+            await waitFor(
+                () => {
+                    expect(query(`#tooltip-node`), `hover out`).to.not.be.domElement();
+                },
+                { timeout: 50 }
+            );
+        });
+
+        it(`should show tooltip on parent focus & hide on blur`, async () => {
+            const { expectHTMLQuery, query } = testDriver.render(() => (
+                <Root>
+                    <div id="parent-node" tabIndex={0}>
+                        <span>parent content</span>
+                        <Tooltip>
+                            <span id="tooltip-node">tooltip content</span>
+                        </Tooltip>
+                    </div>
+                </Root>
+            ));
+
+            const parentNode = expectHTMLQuery(`#parent-node`);
+
+            parentNode.focus();
+
+            const tooltipNode = expectHTMLQuery(`#tooltip-node`);
+            expect(parentNode).domElement().preceding(tooltipNode);
+
+            parentNode.blur();
+
+            await waitFor(() => {
+                expect(query(`#tooltip-node`), `hover out`).to.not.be.domElement();
+            });
+        });
+
+        it(`should persist on mouse out and over overlay`, async () => {
+            const { expectQuery } = testDriver.render(() => (
+                <Root>
+                    <div id="other-node" style={{ padding: `100px` }}>
+                        other node content
+                    </div>
+                    <div id="parent-node">
+                        <span>parent content</span>
+                        <Tooltip mouseDelay={200}>
+                            <span id="tooltip-node">tooltip content</span>
+                        </Tooltip>
+                    </div>
+                </Root>
+            ));
+
+            await hover(`#parent-node`);
+
+            await waitFor(() => {
+                const parentNode = expectQuery(`#parent-node`);
+                const tooltipNode = expectQuery(`#tooltip-node`);
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+
+            await hover(`#other-node`);
+            await hover(`#tooltip-node`);
+
+            await sleep(250);
+
+            await waitFor(() => {
+                const parentNode = expectQuery(`#parent-node`);
+                const tooltipNode = expectQuery(`#tooltip-node`);
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+        });
+
+        it(`should persist on focus in overlay and hide on blur`, async () => {
+            const { expectHTMLQuery, query } = testDriver.render(() => (
+                <Root>
+                    <button id="other-node" style={{ padding: `100px` }}>
+                        other node content
+                    </button>
+                    <div tabIndex={0} id="parent-node">
+                        <span>parent content</span>
+                        <Tooltip>
+                            <button id="tooltip-node">tooltip content</button>
+                        </Tooltip>
+                    </div>
+                </Root>
+            ));
+            const parentNode = expectHTMLQuery(`#parent-node`);
+
+            parentNode.focus();
+
+            await waitFor(() => {
+                const tooltipNode = expectHTMLQuery(`#tooltip-node`);
+                expect(getComputedStyle(tooltipNode).visibility).to.equal('visible');
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+
+            expectHTMLQuery(`#tooltip-node`).focus();
+
+            await sleep(250);
+
+            await waitFor(() => {
+                const tooltipNode = expectHTMLQuery(`#tooltip-node`);
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+
+            expectHTMLQuery(`#other-node`).focus();
+
+            await waitFor(() => {
+                expect(query(`#tooltip-node`), `blur out`).to.not.be.domElement();
+            });
+        });
+
+        it(`should hide tooltip on click outside`, async () => {
+            const { expectHTMLQuery, query } = testDriver.render(() => (
+                <Root>
+                    <div id="parent-node">
+                        <span>parent content</span>
+                        <Tooltip>
+                            <span id="tooltip-node">tooltip content</span>
+                        </Tooltip>
+                    </div>
+                    <div id="outside-node" style={{ width: `200px`, height: `200px` }}></div>
+                </Root>
+            ));
+
+            await hover(`#parent-node`);
+
+            await waitFor(() => {
+                const parentNode = expectHTMLQuery(`#parent-node`);
+                const tooltipNode = expectHTMLQuery(`#tooltip-node`);
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+
+            // direct click with no mouseout event
+            expectHTMLQuery(`#outside-node`).click();
+
+            await waitFor(() => {
+                expect(query(`#tooltip-node`), `click outside`).to.not.be.domElement();
+            });
+        });
+    });
+
+    describe(`position`, () => {
+        it(`should position relative to parent`, async () => {
+            const { expectHTMLQuery } = testDriver.render(() => (
+                <Root
+                    style={{
+                        width: `300px`,
+                        height: `300px`,
+                        display: `grid`,
+                        justifyItems: `center`,
+                        alignContent: `center`,
+                    }}
+                >
+                    <div
+                        id="parent-node"
+                        tabIndex={0}
+                        style={{ width: `100px`, height: `40px`, background: 'red' }}
+                    >
+                        <Tooltip>
+                            <div
+                                id="tooltip-node"
+                                style={{ width: `80px`, height: `20px`, background: 'green' }}
+                            ></div>
+                        </Tooltip>
+                    </div>
+                </Root>
+            ));
+
+            await hover(`#parent-node`);
+
+            await waitFor(() => {
+                const tooltipNode = expectHTMLQuery(`#tooltip-node`);
+                const parentNode = expectHTMLQuery(`#parent-node`);
+                const tooltipBounds = tooltipNode.getBoundingClientRect();
+                const parentBounds = parentNode.getBoundingClientRect();
+                expect(tooltipBounds.bottom, `tooltip above`).to.be.approximately(
+                    parentBounds.top,
+                    1
+                );
+                expect(
+                    tooltipBounds.right - tooltipBounds.width / 2,
+                    `tooltip x centered`
+                ).to.be.approximately(parentBounds.right - parentBounds.width / 2, 1);
+            });
+        });
+    });
+});

--- a/packages/svelte/demo/demos.svelte
+++ b/packages/svelte/demo/demos.svelte
@@ -1,6 +1,7 @@
 <script>
     import { Root } from '../src';
     import ModalDemo from './demos/modal-demo.svelte';
+    import TooltipDemo from './demos/tooltip-demo.svelte';
 </script>
 
 <style>
@@ -29,5 +30,7 @@
         <ModalDemo>
             <svelte:self />
         </ModalDemo>
+        <hr/>
+        <TooltipDemo />
     </div>
 </div>

--- a/packages/svelte/demo/demos/tooltip-demo.svelte
+++ b/packages/svelte/demo/demos/tooltip-demo.svelte
@@ -1,0 +1,64 @@
+<script>
+    import { Tooltip } from '../../src';
+    import Box from '../box.svelte';
+</script>
+
+<h2>Tooltip</h2>
+<div
+    style="
+        display: flex;
+        justify-content: space-evenly;
+        flex-wrap: wrap;
+    "
+>
+    <a href="#nolink">
+        link<Tooltip>
+            <Box shadow>
+                <Box shadow style="padding: 0.5em;">
+                    Tooltip from {`<a />`}
+                </Box>
+            </Box>
+        </Tooltip>
+    </a>
+    <button>
+        button<Tooltip>
+            <Box shadow style="padding: 0.5em;">
+                Tooltip from {`<button />`}
+            </Box>
+        </Tooltip>
+    </button>
+    <div tabIndex={0}>
+        div with tip<Tooltip>
+            <Box shadow style="padding: 0.5em; max-width: 20em;">
+                Don't forget to set the tooltip anchor to be tabbable for keyboard
+                navigation
+            </Box>
+        </Tooltip>
+    </div>
+    <button>
+        interactive tooltip<Tooltip>
+            <Box
+                shadow
+                style="padding: 0.5em; display: grid; justify-items: start;"
+            >
+                <input
+                    value="click or focus into tooltip"
+                />
+                <a href="#nolink">
+                    nested tooltip<Tooltip>
+                        <Box shadow style="padding: 0.5em;">
+                            Tooltip from{' '}
+                            <a href="#nolink">
+                                tooltip?<Tooltip>
+                                    <Box shadow style="padding: 0.5em;">
+                                        ...from tooltip
+                                    </Box>
+                                </Tooltip>
+                            </a>
+                        </Box>
+                    </Tooltip>
+                </a>
+            </Box>
+        </Tooltip>
+    </button>
+</div>

--- a/packages/svelte/src/Layer.svelte
+++ b/packages/svelte/src/Layer.svelte
@@ -5,6 +5,7 @@
     export let backdrop = `none`;
     export let onClickOutside;
     export let onFocusChange;
+    export let onMouseIntersection;
 
     let originRoot;
     let element;
@@ -15,6 +16,11 @@
             backdrop,
             onClickOutside,
             generateElement: false,
+            onMouseIntersection: () => {
+                if (onMouseIntersection) {
+                    onMouseIntersection(layer.state.mouseInside);
+                }
+            },
             onFocusChange: () => {
                 if (onFocusChange) {
                     onFocusChange(layer.state.focusInside);

--- a/packages/svelte/src/Layer.svelte
+++ b/packages/svelte/src/Layer.svelte
@@ -4,6 +4,7 @@
     export let overlap = `window`;
     export let backdrop = `none`;
     export let onClickOutside;
+    export let onFocusChange;
 
     let originRoot;
     let element;
@@ -13,7 +14,12 @@
             overlap,
             backdrop,
             onClickOutside,
-            generateElement: false
+            generateElement: false,
+            onFocusChange: () => {
+                if (onFocusChange) {
+                    onFocusChange(layer.state.focusInside);
+                }
+            },
         }
     });
 

--- a/packages/svelte/src/Root.svelte
+++ b/packages/svelte/src/Root.svelte
@@ -23,7 +23,7 @@
     setContext(`zeejs-context`, rootLayer);
 
     onMount(() => {
-        const { stop: stopFocus } = watchFocus(wrapper);
+        const { stop: stopFocus } = watchFocus(wrapper, rootLayer);
         const { stop: stopClickOutside } = watchClickOutside(wrapper, rootLayer, backdrop);
         onChange();
         return () => {

--- a/packages/svelte/src/Root.svelte
+++ b/packages/svelte/src/Root.svelte
@@ -72,6 +72,9 @@
         right: 0;
         bottom: 0;
     }
+    :global(.zeejs--notPlaced), :global(.zeejs--notPlaced) * {
+        visibility: hidden!important;
+    }
 </style>
 
 <div bind:this={wrapper}>

--- a/packages/svelte/src/Root.svelte
+++ b/packages/svelte/src/Root.svelte
@@ -4,6 +4,7 @@
         updateLayers,
         watchFocus,
         watchClickOutside,
+        watchMouseInside,
         createBackdropParts
     } from '@zeejs/browser';
     import { setContext, onMount } from 'svelte';
@@ -25,10 +26,12 @@
     onMount(() => {
         const { stop: stopFocus } = watchFocus(wrapper, rootLayer);
         const { stop: stopClickOutside } = watchClickOutside(wrapper, rootLayer, backdrop);
+        const { stop: stopMouseInside } = watchMouseInside(wrapper, rootLayer, backdrop);
         onChange();
         return () => {
             stopFocus();
             stopClickOutside();
+            stopMouseInside();
         };
     });
 </script>

--- a/packages/svelte/src/Tooltip.svelte
+++ b/packages/svelte/src/Tooltip.svelte
@@ -1,0 +1,45 @@
+<script>
+    import Layer from './Layer.svelte';
+    import { tooltip, isContainedBy } from '@zeejs/browser';
+    import { onMount, afterUpdate } from 'svelte';
+
+    export let mouseDelay;
+
+    let placeholderRef;
+    let overlayRef;
+    let isOpen = false;
+    const tooltipLogic = tooltip({
+        onToggle() {
+            isOpen = !isOpen;
+        },
+        mouseDelay,
+        isInOverlay: isContainedBy,
+    });
+
+    onMount(() => {
+        const anchor = placeholderRef.parentElement;
+        if (!anchor) {
+            return;
+        }
+        tooltipLogic.setAnchor(anchor);
+        return () => tooltipLogic.stop();
+    });
+    afterUpdate(() => {
+        tooltipLogic.setOverlay(overlayRef);
+    });
+</script>
+
+<span bind:this={placeholderRef}>
+    {#if isOpen}
+        <Layer
+            onFocusChange={tooltipLogic.flagOverlayFocus}
+            onMouseIntersection={tooltipLogic.flagMouseOverOverlay}
+            onClickOutside={() => tooltipLogic.flagOverlayFocus(false)}
+        >
+            <div bind:this={overlayRef} className={tooltipLogic.initialOverlayCSSClass}>
+                <slot />
+            </div>
+        </Layer>
+    {/if}
+</span>
+

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,2 +1,3 @@
 export { default as Root } from './Root.svelte';
 export { default as Layer } from './Layer.svelte';
+export { default as Tooltip } from './Tooltip.svelte';

--- a/packages/svelte/test/root-and-layer.spec.tsx
+++ b/packages/svelte/test/root-and-layer.spec.tsx
@@ -1,43 +1,52 @@
-import { Root, Layer } from '../src';
+import * as zeejsSvelte from '../src';
 import { domElementMatchers } from './chai-dom-element';
-import { ReactTestDriver } from './react-test-driver';
+import RenderRootServerFixture from './server-fixtures/RenderRoot.svelte';
+import RenderLayerServerFixture from './server-fixtures/RenderLayer.svelte';
+import { SvelteTestDriver } from './svelte-test-driver';
 import {
     expectImageSnapshot,
     getInteractionApi,
     expectServerFixture,
 } from '@zeejs/test-browser/browser';
-import React from 'react';
-import ReactDOM from 'react-dom';
 import { waitFor } from 'promise-assist';
 import chai, { expect } from 'chai';
 import sinon, { stub, spy } from 'sinon';
 import sinonChai from 'sinon-chai';
-import { act } from 'react-dom/test-utils';
 chai.use(sinonChai);
 chai.use(domElementMatchers);
 
-describe(`react`, () => {
-    let testDriver: ReactTestDriver;
+describe(`svelte`, () => {
+    let testDriver: SvelteTestDriver;
     const { click, clickIfPossible, keyboard, hover } = getInteractionApi();
 
-    before('setup test driver', () => (testDriver = new ReactTestDriver()));
+    before('setup test driver', () => {
+        testDriver = new SvelteTestDriver({
+            '@zeejs/svelte': zeejsSvelte,
+        });
+    });
     afterEach('clear test driver', () => {
         testDriver.clean();
         sinon.restore();
     });
 
     it(`should render main layer`, () => {
-        const { container } = testDriver.render(() => (
+        const { container } = testDriver.render(`
+            <script>
+                import {Root} from '@zeejs/svelte';
+            </script>
             <Root>
                 <div>content</div>
             </Root>
-        ));
+        `);
 
         expect(container.textContent).to.equal(`content`);
     });
 
     it(`should position layer after main layer in DOM`, () => {
-        const { expectQuery } = testDriver.render(() => (
+        const { expectQuery } = testDriver.render(`
+            <script>
+                import {Root, Layer} from '@zeejs/svelte';
+            </script>
             <Root>
                 <div id="root-node">
                     <Layer>
@@ -45,7 +54,7 @@ describe(`react`, () => {
                     </Layer>
                 </div>
             </Root>
-        ));
+        `);
 
         const rootNode = expectQuery(`#root-node`);
         const layerNode = expectQuery(`#layer-node`);
@@ -53,84 +62,81 @@ describe(`react`, () => {
         expect(rootNode, `layer after root`).domElement().preceding(layerNode);
     });
 
-    it(`should render layer after initial render`, () => {
-        const { expectQuery, query, setData } = testDriver.render<boolean>(
-            (renderLayer) => (
-                <Root>
-                    <div id="root-node">
-                        {renderLayer ? (
-                            <Layer>
-                                <div id="layer-node" />
-                            </Layer>
-                        ) : null}
-                    </div>
-                </Root>
-            ),
-            {
-                initialData: false,
-            }
-        );
+    it(`should render layer after initial render`, async () => {
+        const { expectQuery, query, updateProps } = testDriver.render(`
+            <script>
+                import {Root, Layer} from '@zeejs/svelte';
+                export let renderLayer = false;
+            </script>
+            <Root>
+                <div id="root-node">
+                    {#if renderLayer}
+                        <Layer>
+                            <div id="layer-node" />
+                        </Layer>
+                    {/if}
+                </div>
+            </Root>
+        `);
 
         expect(query(`#layer-node`), `before layer render`).to.not.be.domElement();
 
-        setData(true);
+        await updateProps({ renderLayer: true });
 
         const rootNode = expectQuery(`#root-node`);
         const layerNode = expectQuery(`#layer-node`);
         expect(rootNode).domElement().preceding(layerNode);
     });
 
-    it(`should remove layer`, () => {
-        const { container } = testDriver.render(() => (
+    it(`should remove layer`, async () => {
+        const { container, updateProps } = testDriver.render(`
+            <script>
+                import {Root, Layer} from '@zeejs/svelte';
+                export let renderLayer = true;
+            </script>
             <Root>
                 <div id="root-node">
-                    <Layer>
-                        <div id="layer-node" />
-                    </Layer>
+                    {#if renderLayer}
+                        <Layer>
+                            <div id="layer-node" />
+                        </Layer>
+                    {/if}
                 </div>
             </Root>
-        ));
+        `);
 
-        testDriver.render(
-            () => (
-                <Root>
-                    <div id="root-node" />
-                </Root>
-            ),
-            { container }
-        );
+        await updateProps({ renderLayer: false });
 
         const layerNode = container.querySelector(`#layer-node`);
         expect(layerNode, `layer not rendered`).to.equal(null);
         expect(container.firstElementChild?.childElementCount, `only root content`).to.equal(1);
     });
 
-    it(`should render and remove deep nested layer`, () => {
-        const { expectQuery, query, setData } = testDriver.render<boolean>(
-            (renderLayer) => (
-                <Root>
-                    <div id="main">
-                        <Layer>
-                            <div id="shallow">
-                                {renderLayer ? (
-                                    <Layer>
-                                        <div id="deep" />
-                                    </Layer>
-                                ) : null}
-                            </div>
-                        </Layer>
-                    </div>
-                </Root>
-            ),
-            {
-                initialData: false,
-            }
-        );
+    it(`should render and remove deep nested layer`, async () => {
+        const { updateProps, query, expectQuery } = testDriver.render(`
+            <script>
+                import {Root, Layer} from '@zeejs/svelte';
+                export let renderLayer = false;
+            </script>
+            <Root>
+                <div id="main">
+                    <Layer>
+                        <div id="shallow">
+                            {#if renderLayer}
+                                <Layer>
+                                    <div id="deep" />
+                                </Layer>
+                            {/if}
+                        </div>
+                    </Layer>
+                </div>
+            </Root>
+        `);
 
         expect(query(`#deep`), `not rendered`).to.not.be.domElement();
 
         // render deep layer
-        setData(true);
+        await updateProps({ renderLayer: true });
 
         const mainNode = expectQuery(`#main`);
         const shallowNode = expectQuery(`#shallow`);
@@ -139,28 +145,28 @@ describe(`react`, () => {
         expect(shallowNode, `shallow before deep`).domElement().preceding(deepNode);
 
         // render without deep layer
-        setData(false);
+        await updateProps({ renderLayer: false });
 
         expect(query(`#deep`), `not rendered`).to.not.be.domElement();
     });
 
     it(`should place layer relative to window (default)`, () => {
         const { innerWidth, innerHeight } = window;
-        const { expectQuery } = testDriver.render(() => (
+        const { expectQuery } = testDriver.render(`
+            <script>
+                import {Root, Layer} from '@zeejs/svelte';
+            </script>
             <Root>
                 <div
                     id="root-node"
-                    style={{
-                        height: innerHeight * 2,
-                        width: innerWidth * 2,
-                    }}
+                    style="height: 200vh; width: 200vw;"
                 >
                     <Layer>
-                        <div id="layer-node" style={{ width: `100%`, height: `100%` }} />
+                        <div id="layer-node" style="width: 100%; height: 100%;" />
                     </Layer>
                 </div>
             </Root>
-        ));
+        `);
 
         window.scrollTo(innerWidth, innerHeight);
 
@@ -173,64 +179,47 @@ describe(`react`, () => {
         });
     });
 
-    it(`should place layer relative to element`, () => {
+    it(`should place layer relative to element`, async () => {
         const { innerWidth, innerHeight } = window;
-        const { expectHTMLQuery, container } = testDriver.render(() => (
+        const { expectHTMLQuery } = testDriver.render(`
+            <script>
+                import {Root, Layer} from '@zeejs/svelte';
+                let relativeNode;
+            </script>
             <Root>
                 <div
                     id="root-node"
-                    style={{
-                        height: innerHeight * 2,
-                        width: innerWidth * 2,
-                    }}
+                    style="height: 200vh; width: 200vw;"
                 >
                     <div
+                        bind:this={relativeNode}
                         id="relative-node"
-                        style={{
-                            width: `200px`,
-                            height: `100px`,
-                            margin: `30px`,
-                        }}
+                        style="width: 200px; height: 100px; margin: 30px;"
                     />
+                    {#if relativeNode}
+                        <Layer overlap={relativeNode}>
+                            <div id="layer-node" style="width: 100%; height: 100%;" />
+                        </Layer>
+                    {/if}
                 </div>
             </Root>
-        ));
+        `);
         const relativeNode = expectHTMLQuery(`#relative-node`);
 
-        testDriver.render(
-            () => (
-                <Root>
-                    <div
-                        id="root-node"
-                        style={{
-                            height: innerHeight * 2,
-                            width: innerWidth * 2,
-                        }}
-                    >
-                        <div
-                            id="relative-node"
-                            style={{
-                                width: `200px`,
-                                height: `100px`,
-                                margin: `30px`,
-                            }}
-                        />
-                        <Layer overlap={relativeNode}>
-                            <div id="layer-node" style={{ width: `100%`, height: `100%` }} />
-                        </Layer>
-                    </div>
-                </Root>
-            ),
-            { container }
-        );
         window.scrollTo(innerWidth, innerHeight);
 
         const layerNode = expectHTMLQuery(`#layer-node`);
-        expect(layerNode.getBoundingClientRect()).to.eql(relativeNode.getBoundingClientRect());
+        await waitFor(() => {
+            expect(layerNode.getBoundingClientRect()).to.eql(relativeNode.getBoundingClientRect());
+        });
     });
 
     it(`should hide layer component placeholder inline`, () => {
-        const { expectQuery } = testDriver.render(() => (
+        const { expectQuery } = testDriver.render(`
+            <script>
+                import {Root, Layer} from '@zeejs/svelte';
+                let relativeNode;
+            </script>
             <Root>
                 <div id="root-node">
                     <span id="before">before</span>
@@ -240,7 +229,7 @@ describe(`react`, () => {
                     <span id="after">after</span>
                 </div>
             </Root>
-        ));
+        `);
 
         const before = expectQuery(`#before`);
         const layerPlaceholder = before.nextElementSibling!;
@@ -266,18 +255,25 @@ describe(`react`, () => {
     describe(`backdrop`, () => {
         it(`should click through backdrop by default (backdrop="none")`, async () => {
             const contentClick = stub();
-            testDriver.render(() => (
+            testDriver.render(
+                `
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let contentClick;
+                </script>
                 <Root>
                     <div
                         id="back-item"
-                        onClick={() => contentClick()}
-                        style={{ width: `400px`, height: `400px` }}
+                        on:click={contentClick}
+                        style="width: 400px; height: 400px;"
                     />
                     <Layer>
                         <span />
                     </Layer>
                 </Root>
-            ));
+            `,
+                { contentClick }
+            );
 
             await click(`#back-item`);
 
@@ -286,18 +282,25 @@ describe(`react`, () => {
 
         it(`should prevent clicks through "block" backdrop`, async () => {
             const contentClick = stub();
-            testDriver.render(() => (
+            testDriver.render(
+                `
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let contentClick;
+                </script>
                 <Root>
                     <div
                         id="back-item"
-                        onClick={() => contentClick()}
-                        style={{ width: `400px`, height: `400px` }}
+                        on:click={contentClick}
+                        style="width: 400px; height: 400px;"
                     />
                     <Layer backdrop="block">
                         <span />
                     </Layer>
                 </Root>
-            ));
+            `,
+                { contentClick }
+            );
 
             expect(await clickIfPossible(`#back-item`), `not clickable`).to.equal(false);
             expect(contentClick).to.have.callCount(0);
@@ -305,20 +308,27 @@ describe(`react`, () => {
 
         it(`should prevent clicks on other layers through "block" backdrop`, async () => {
             const contentClick = stub();
-            testDriver.render(() => (
+            testDriver.render(
+                `
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let contentClick;
+                </script>
                 <Root>
                     <Layer backdrop="block">
                         <div
                             id="layer-item"
-                            onClick={() => contentClick()}
-                            style={{ width: `400px`, height: `400px` }}
+                            on:click={contentClick}
+                            style="width: 400px; height: 400px;"
                         />
                     </Layer>
                     <Layer backdrop="block">
                         <span />
                     </Layer>
                 </Root>
-            ));
+            `,
+                { contentClick }
+            );
 
             expect(await clickIfPossible(`#layer-item`), `not clickable`).to.equal(false);
             expect(contentClick).to.have.callCount(0);
@@ -326,20 +336,27 @@ describe(`react`, () => {
 
         it(`should click through to other layers with "none" backdrop (default)`, async () => {
             const contentClick = stub();
-            testDriver.render(() => (
+            testDriver.render(
+                `
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let contentClick;
+                </script>
                 <Root>
                     <Layer backdrop="block">
                         <div
                             id="layer-item"
-                            onClick={() => contentClick()}
-                            style={{ width: `400px`, height: `400px` }}
+                            on:click={contentClick}
+                            style="width: 400px; height: 400px;"
                         />
                     </Layer>
                     <Layer backdrop="none">
                         <span />
                     </Layer>
                 </Root>
-            ));
+            `,
+                { contentClick }
+            );
 
             await click(`#layer-item`);
 
@@ -348,28 +365,27 @@ describe(`react`, () => {
 
         it(`should hide content behind layer (backdrop="hide")`, async () => {
             const contentClick = stub();
-            testDriver.render(() => (
+            testDriver.render(
+                `
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let contentClick;
+                </script>
                 <Root>
                     <div
                         id="back-item"
-                        onClick={() => contentClick()}
-                        style={{
-                            width: `400px`,
-                            height: `400px`,
-                            background: `green`,
-                        }}
+                        on:click={contentClick}
+                        style="width: 400px; height: 400px; background: green;"
                     />
                     <Layer backdrop="hide">
                         <div
-                            style={{
-                                width: `200px`,
-                                height: `200px`,
-                                background: `green`,
-                            }}
+                            style="width: 200px; height: 200px; background: green;"
                         />
                     </Layer>
                 </Root>
-            ));
+            `,
+                { contentClick }
+            );
 
             expect(await clickIfPossible(`#back-item`), `not clickable`).to.equal(false);
 
@@ -380,37 +396,26 @@ describe(`react`, () => {
         });
 
         it(`should hide content between layers (backdrop="hide")`, async () => {
-            testDriver.render(() => (
+            testDriver.render(`
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                </script>
                 <Root>
                     <div
-                        style={{
-                            width: `400px`,
-                            height: `400px`,
-                            background: `green`,
-                        }}
+                        style="width: 400px; height: 400px; background: green;"
                     />
                     <Layer backdrop="hide">
                         <div
-                            style={{
-                                width: `200px`,
-                                height: `200px`,
-                                position: `absolute`,
-                                right: 0,
-                                background: `green`,
-                            }}
+                            style="width: 200px; height: 200px; position: absolute; right: 0; background: green;"
                         />
                     </Layer>
                     <Layer backdrop="hide">
                         <div
-                            style={{
-                                width: `100px`,
-                                height: `100px`,
-                                background: `green`,
-                            }}
+                            style="width: 100px; height: 100px; background: green;"
                         />
                     </Layer>
                 </Root>
-            ));
+            `);
 
             await expectImageSnapshot({
                 filePath: `backdrop/should hide content between layer (backdrop=hide)`,
@@ -420,7 +425,10 @@ describe(`react`, () => {
 
     describe(`focus`, () => {
         it(`should keep layer as part of tab order`, async () => {
-            const { expectHTMLQuery } = testDriver.render<boolean>(() => (
+            const { expectHTMLQuery } = testDriver.render(`
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                </script>
                 <Root>
                     <input id="bgBeforeInput" />
                     <Layer>
@@ -428,7 +436,7 @@ describe(`react`, () => {
                     </Layer>
                     <input id="bgAfterInput" />
                 </Root>
-            ));
+            `);
             const bgBeforeInput = expectHTMLQuery(`#bgBeforeInput`);
             const layerInput = expectHTMLQuery(`#layerInput`);
             const bgAfterInput = expectHTMLQuery(`#bgAfterInput`);
@@ -444,7 +452,10 @@ describe(`react`, () => {
         });
 
         it(`should trap focus in blocking layer`, async () => {
-            const { expectHTMLQuery } = testDriver.render<boolean>(() => (
+            const { expectHTMLQuery } = testDriver.render(`
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                </script>
                 <Root>
                     <input id="bgBeforeInput" />
                     <Layer backdrop="block">
@@ -453,7 +464,7 @@ describe(`react`, () => {
                     </Layer>
                     <input id="bgAfterInput" />
                 </Root>
-            ));
+            `);
             const layerFirstInput = expectHTMLQuery(`#layerFirstInput`);
             const layerLastInput = expectHTMLQuery(`#layerLastInput`);
 
@@ -465,47 +476,48 @@ describe(`react`, () => {
         });
 
         it(`should re-focus last element of an un-blocked layer`, async () => {
-            const warnSpy = spy(console, `warn`);
-            const errorSpy = spy(console, `error`);
-            const { expectHTMLQuery, setData } = testDriver.render<boolean>(
-                (renderLayer) => (
-                    <Root>
-                        <input id="bgInput" />
-                        {renderLayer ? <Layer backdrop="block">layer content</Layer> : null}
-                    </Root>
-                ),
-                { initialData: false }
-            );
+            const { expectHTMLQuery, updateProps } = testDriver.render(`
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let renderLayer = false;
+                </script>
+                <Root>
+                    <input id="bgInput" />
+                    {#if renderLayer}
+                        <Layer backdrop="block">layer content</Layer>
+                    {/if}
+                </Root>
+            `);
             const bgInput = expectHTMLQuery(`#bgInput`);
             bgInput.focus();
 
-            setData(true);
+            await updateProps({ renderLayer: true });
 
-            await waitFor(() => {
-                expect(document.activeElement, `blocked input blur`).to.equal(document.body);
-            });
+            expect(document.activeElement, `blocked input blur`).to.equal(document.body);
 
-            setData(false);
+            await updateProps({ renderLayer: false });
 
-            await waitFor(() => {
-                expect(document.activeElement, `refocus input`).to.equal(bgInput);
-            });
-            /* blur/re-focus is delayed because React listens for blur of rendered elements during render.
-            just check that no logs have been called. */
-            expect(warnSpy, `no react warning`).to.have.callCount(0);
-            expect(errorSpy, `no react error`).to.have.callCount(0);
+            expect(document.activeElement, `refocus input`).to.equal(bgInput);
         });
 
         it(`should report on focus change`, async () => {
             const onFocusChange = stub();
-            testDriver.render(() => (
+            testDriver.render(
+                `
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let onFocusChange;
+                </script>
                 <Root>
                     <input id="root-input" />
                     <Layer onFocusChange={onFocusChange}>
-                        <input id="layer-input" style={{ margin: `1em` }} />
+                        <input id="layer-input" style="margin: 1em;" />
                     </Layer>
                 </Root>
-            ));
+                         />
+            `,
+                { onFocusChange }
+            );
 
             await click(`#layer-input`);
 
@@ -521,21 +533,22 @@ describe(`react`, () => {
     describe(`click outside`, () => {
         it(`should invoke onClickOutside handler for click on root`, async () => {
             const onClickOutside = stub();
-            testDriver.render(() => (
+            testDriver.render(
+                `
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let onClickOutside;
+                </script>
                 <Root>
-                    <div
-                        id="root-node"
-                        style={{ width: `100px`, height: `100px`, background: `green` }}
-                    >
+                    <div id="root-node" style="width: 100px; height: 100px; background: green;">
                         <Layer onClickOutside={onClickOutside}>
-                            <div
-                                id="layer-node"
-                                style={{ width: `50px`, height: `50px`, background: `red` }}
-                            />
+                            <div id="layer-node" style="width: 50px; height: 50px; background: red;" />
                         </Layer>
                     </div>
                 </Root>
-            ));
+            `,
+                { onClickOutside }
+            );
 
             await click(`#root-node`);
 
@@ -548,27 +561,25 @@ describe(`react`, () => {
 
         it(`should not invoke onClickOutside handler for nested layer click`, async () => {
             const onClickOutside = stub();
-            testDriver.render(() => (
+            testDriver.render(
+                `
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let onClickOutside;
+                </script>
                 <Root>
-                    <div
-                        id="root-node"
-                        style={{ width: `100px`, height: `100px`, background: `green` }}
-                    >
+                    <div id="root-node" style="width: 100px; height: 100px; background: green;">
                         <Layer onClickOutside={onClickOutside}>
-                            <div
-                                id="shallow-node"
-                                style={{ width: `50px`, height: `50px`, background: `orange` }}
-                            />
+                            <div id="shallow-node" style="width: 50px; height: 50px; background: orange;" />
                             <Layer>
-                                <div
-                                    id="deep-node"
-                                    style={{ width: `25px`, height: `25px`, background: `red` }}
-                                />
+                                <div id="deep-node" style="width: 25px; height: 25px; background: red;" />
                             </Layer>
                         </Layer>
                     </div>
                 </Root>
-            ));
+            `,
+                { onClickOutside }
+            );
 
             await click(`#deep-node`);
 
@@ -579,21 +590,22 @@ describe(`react`, () => {
     describe(`mouse inside`, () => {
         it(`should inform layer when mouse enters and leaves`, async () => {
             const onMouseIntersection = stub();
-            testDriver.render(() => (
+            testDriver.render(
+                `
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let onMouseIntersection;
+                </script>
                 <Root>
-                    <div
-                        id="root-node"
-                        style={{ width: `100px`, height: `100px`, background: `green` }}
-                    >
+                    <div id="root-node" style="width: 100px; height: 100px; background: green;">
                         <Layer onMouseIntersection={onMouseIntersection}>
-                            <div
-                                id="layer-node"
-                                style={{ width: `50px`, height: `50px`, background: `red` }}
-                            />
+                            <div id="layer-node" style="width: 50px; height: 50px; background: red;" />
                         </Layer>
                     </div>
                 </Root>
-            ));
+            `,
+                { onMouseIntersection }
+            );
 
             await hover(`#layer-node`);
 
@@ -617,20 +629,22 @@ describe(`react`, () => {
             const warnSpy = spy(console, `warn`);
             const errorSpy = spy(console, `error`);
             const container = document.createElement(`div`);
-            document.body.appendChild(container);
 
-            container.innerHTML = await expectServerFixture({
-                fixtureFileName: `render-root.tsx`,
+            // ToDo: test CSS once figured out how best to deliver it...
+            const { html } = await expectServerFixture({
+                fixtureFileName: `server-render.ts`,
+                exportName: `renderRoot`,
+            });
+            container.innerHTML = html;
+
+            new RenderRootServerFixture({
+                target: container,
+                hydrate: true,
             });
 
-            act(() => {
-                ReactDOM.hydrate(<Root>content</Root>, container);
-            });
-
-            expect(container.textContent).to.equal(`content`);
-            expect(warnSpy, `no react warning`).to.have.callCount(0);
-            expect(errorSpy, `no react error`).to.have.callCount(0);
-            document.body.removeChild(container);
+            expect(container.textContent?.trim()).to.equal(`content`);
+            expect(warnSpy, `no svelte warning`).to.have.callCount(0);
+            expect(errorSpy, `no svelte error`).to.have.callCount(0);
         });
 
         it(`should render layers nested and flattened in browser`, async () => {
@@ -639,32 +653,24 @@ describe(`react`, () => {
             const container = document.createElement(`div`);
             document.body.appendChild(container);
 
-            container.innerHTML = await expectServerFixture({
-                fixtureFileName: `render-layer.tsx`,
+            const { html } = await expectServerFixture({
+                fixtureFileName: `server-render.ts`,
+                exportName: `renderLayer`,
             });
+            container.innerHTML = html;
 
-            let rootNode = testDriver.expectHTMLQuery(container, `#root-node`);
-            let layerNode = testDriver.expectHTMLQuery(container, `#layer-node`);
+            const rootNode = testDriver.expectHTMLQuery(container, `#root-node`);
+            const layerNode = testDriver.expectHTMLQuery(container, `#layer-node`);
             expect(rootNode, `root exist in string`).domElement();
             expect(rootNode, `layer inside root before client render`)
                 .domElement()
                 .contains(layerNode);
 
-            act(() => {
-                ReactDOM.hydrate(
-                    <Root>
-                        <div id="root-node">
-                            <Layer>
-                                <div id="layer-node" />
-                            </Layer>
-                        </div>
-                    </Root>,
-                    container
-                );
+            new RenderLayerServerFixture({
+                target: container,
+                hydrate: true,
             });
 
-            rootNode = testDriver.expectHTMLQuery(container, `#root-node`);
-            layerNode = testDriver.expectHTMLQuery(container, `#layer-node`);
             expect(layerNode, `layer exist after client render`).domElement();
             expect(rootNode, `layer after root`).domElement().preceding(layerNode);
             expect(warnSpy, `no react warning`).to.have.callCount(0);

--- a/packages/svelte/test/test.spec.tsx
+++ b/packages/svelte/test/test.spec.tsx
@@ -16,7 +16,7 @@ chai.use(domElementMatchers);
 
 describe(`svelte`, () => {
     let testDriver: SvelteTestDriver;
-    const { click, clickIfPossible, keyboard } = getInteractionApi();
+    const { click, clickIfPossible, keyboard, hover } = getInteractionApi();
 
     before('setup test driver', () => {
         testDriver = new SvelteTestDriver({
@@ -581,6 +581,43 @@ describe(`svelte`, () => {
             await click(`#deep-node`);
 
             expect(onClickOutside, `no invocation for nested click`).to.have.callCount(0);
+        });
+    });
+
+    describe(`mouse inside`, () => {
+        it(`should inform layer when mouse enters and leaves`, async () => {
+            const onMouseIntersection = stub();
+            testDriver.render(
+                `
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let onMouseIntersection;
+                </script>
+                <Root>
+                    <div id="root-node" style="width: 100px; height: 100px; background: green;">
+                        <Layer onMouseIntersection={onMouseIntersection}>
+                            <div id="layer-node" style="width: 50px; height: 50px; background: red;" />
+                        </Layer>
+                    </div>
+                </Root>
+            `,
+                { onMouseIntersection }
+            );
+
+            await hover(`#layer-node`);
+
+            await waitFor(() => {
+                expect(onMouseIntersection, `catch mouse inside layer`).to.have.callCount(1);
+                expect(onMouseIntersection, `called with true`).to.have.been.calledWith(true);
+            });
+            onMouseIntersection.reset();
+
+            await hover(`#root-node`);
+
+            await waitFor(() => {
+                expect(onMouseIntersection, `catch mouse outside layer`).to.have.callCount(1);
+                expect(onMouseIntersection, `called with false`).to.have.been.calledWith(false);
+            });
         });
     });
 

--- a/packages/svelte/test/test.spec.tsx
+++ b/packages/svelte/test/test.spec.tsx
@@ -8,6 +8,7 @@ import {
     getInteractionApi,
     expectServerFixture,
 } from '@zeejs/test-browser/browser';
+import { waitFor } from 'promise-assist';
 import chai, { expect } from 'chai';
 import sinon, { stub, spy } from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/packages/svelte/test/test.spec.tsx
+++ b/packages/svelte/test/test.spec.tsx
@@ -496,6 +496,35 @@ describe(`svelte`, () => {
 
             expect(document.activeElement, `refocus input`).to.equal(bgInput);
         });
+
+        it(`should report on focus change`, async () => {
+            const onFocusChange = stub();
+            testDriver.render(
+                `
+                <script>
+                    import {Root, Layer} from '@zeejs/svelte';
+                    export let onFocusChange;
+                </script>
+                <Root>
+                    <input id="root-input" />
+                    <Layer onFocusChange={onFocusChange}>
+                        <input id="layer-input" style="margin: 1em;" />
+                    </Layer>
+                </Root>
+                         />
+            `,
+                { onFocusChange }
+            );
+
+            await click(`#layer-input`);
+
+            expect(onFocusChange, `focus in layer`).to.have.been.calledOnceWith(true);
+            onFocusChange.reset();
+
+            await click(`#root-input`);
+
+            expect(onFocusChange, `focus out of layer`).to.have.been.calledOnceWith(false);
+        });
     });
 
     describe(`click outside`, () => {

--- a/packages/svelte/test/tooltip.spec.ts
+++ b/packages/svelte/test/tooltip.spec.ts
@@ -1,0 +1,285 @@
+import * as zeejsSvelte from '../src';
+import { SvelteTestDriver } from './svelte-test-driver';
+import { getInteractionApi } from '@zeejs/test-browser/browser';
+import { waitFor, sleep } from 'promise-assist';
+import { expect } from 'chai';
+
+describe(`svelte tooltip`, () => {
+    let testDriver: SvelteTestDriver;
+    const { hover } = getInteractionApi();
+
+    before('setup test driver', () => {
+        testDriver = new SvelteTestDriver({
+            '@zeejs/svelte': zeejsSvelte,
+        });
+    });
+    afterEach('clear test driver', () => {
+        testDriver.clean();
+    });
+
+    describe(`open state`, () => {
+        it(`should show tooltip on parent element hover & hide on out (default 0.5s delay)`, async () => {
+            const { expectQuery, query } = testDriver.render(`
+                <script>
+                    import {Root, Tooltip} from '@zeejs/svelte';
+                </script>
+                <Root>
+                    <div id="other-node" style="padding: 100px">
+                        other node content
+                    </div>
+                    <div id="parent-node">
+                        <span>parent content</span>
+                        <Tooltip>
+                            <span id="tooltip-node">tooltip content</span>
+                        </Tooltip>
+                    </div>
+                </Root>
+            `);
+
+            expect(query(`#tooltip-node`), `before hover`).to.not.be.domElement();
+
+            await hover(`#parent-node`);
+
+            await waitFor(() => {
+                const parentNode = expectQuery(`#parent-node`);
+                const tooltipNode = expectQuery(`#tooltip-node`);
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+
+            await hover(`#other-node`);
+
+            await waitFor(() => {
+                expect(query(`#tooltip-node`), `hover out`).to.not.be.domElement();
+            });
+        });
+
+        it(`should show tooltip on parent element hover & hide on out with custom mouse delay`, async () => {
+            const { expectQuery, query } = testDriver.render(`
+                <script>
+                    import {Root, Tooltip} from '@zeejs/svelte';
+                </script>
+                <Root>
+                    <div id="other-node" style="padding: 100px">
+                        other node content
+                    </div>
+                    <div id="parent-node">
+                        <span>parent content</span>
+                        <Tooltip mouseDelay={10}>
+                            <span id="tooltip-node">tooltip content</span>
+                        </Tooltip>
+                    </div>
+                </Root>
+            `);
+
+            expect(query(`#tooltip-node`), `before hover`).to.not.be.domElement();
+
+            await hover(`#parent-node`);
+
+            // should be ready before hover is returned
+            await waitFor(
+                () => {
+                    const parentNode = expectQuery(`#parent-node`);
+                    const tooltipNode = expectQuery(`#tooltip-node`);
+                    expect(parentNode).domElement().preceding(tooltipNode);
+                },
+                { timeout: 50 }
+            );
+
+            await hover(`#other-node`);
+
+            await waitFor(
+                () => {
+                    expect(query(`#tooltip-node`), `hover out`).to.not.be.domElement();
+                },
+                { timeout: 50 }
+            );
+        });
+
+        it(`should show tooltip on parent focus & hide on blur`, async () => {
+            const { expectHTMLQuery, query } = testDriver.render(`
+                <script>
+                    import {Root, Tooltip} from '@zeejs/svelte';
+                </script>
+                <Root>
+                    <div id="parent-node" tabIndex="0">
+                        <span>parent content</span>
+                        <Tooltip>
+                            <span id="tooltip-node">tooltip content</span>
+                        </Tooltip>
+                    </div>
+                </Root>
+            `);
+
+            const parentNode = expectHTMLQuery(`#parent-node`);
+            parentNode.focus();
+
+            await waitFor(() => {
+                const tooltipNode = expectHTMLQuery(`#tooltip-node`);
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+
+            parentNode.blur();
+
+            await waitFor(() => {
+                expect(query(`#tooltip-node`), `hover out`).to.not.be.domElement();
+            });
+        });
+
+        it(`should persist on mouse out and over overlay`, async () => {
+            const { expectQuery } = testDriver.render(`
+                <script>
+                    import {Root, Tooltip} from '@zeejs/svelte';
+                </script>
+                <Root>
+                    <div id="other-node" style="padding: 100px">
+                        other node content
+                    </div>
+                    <div id="parent-node">
+                        <span>parent content</span>
+                        <Tooltip mouseDelay={200}>
+                            <span id="tooltip-node">tooltip content</span>
+                        </Tooltip>
+                    </div>
+                </Root>
+            `);
+
+            await hover(`#parent-node`);
+
+            await waitFor(() => {
+                const parentNode = expectQuery(`#parent-node`);
+                const tooltipNode = expectQuery(`#tooltip-node`);
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+
+            await hover(`#other-node`);
+            await hover(`#tooltip-node`);
+
+            await sleep(250);
+
+            await waitFor(() => {
+                const parentNode = expectQuery(`#parent-node`);
+                const tooltipNode = expectQuery(`#tooltip-node`);
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+        });
+
+        it(`should persist on focus in overlay and hide on blur`, async () => {
+            const { expectHTMLQuery, query } = testDriver.render(`
+                <script>
+                    import {Root, Tooltip} from '@zeejs/svelte';
+                </script>
+                <Root>
+                    <button id="other-node" style="padding: 100px">
+                        other node content
+                    </button>
+                    <div tabIndex={0} id="parent-node">
+                        <span>parent content</span>
+                        <Tooltip>
+                            <button id="tooltip-node">tooltip content</button>
+                        </Tooltip>
+                    </div>
+                </Root>
+            `);
+            const parentNode = expectHTMLQuery(`#parent-node`);
+
+            parentNode.focus();
+
+            await waitFor(() => {
+                const tooltipNode = expectHTMLQuery(`#tooltip-node`);
+                expect(getComputedStyle(tooltipNode).visibility).to.equal('visible');
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+
+            expectHTMLQuery(`#tooltip-node`).focus();
+
+            await sleep(250);
+
+            await waitFor(() => {
+                const tooltipNode = expectHTMLQuery(`#tooltip-node`);
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+
+            expectHTMLQuery(`#other-node`).focus();
+
+            await waitFor(() => {
+                expect(query(`#tooltip-node`), `blur out`).to.not.be.domElement();
+            });
+        });
+
+        it(`should hide tooltip on click outside`, async () => {
+            const { expectHTMLQuery, query } = testDriver.render(`
+                <script>
+                    import {Root, Tooltip} from '@zeejs/svelte';
+                </script>
+                <Root>
+                    <div id="parent-node" tabIndex="0">
+                        <span>parent content</span>
+                        <Tooltip>
+                            <span id="tooltip-node">tooltip content</span>
+                        </Tooltip>
+                    </div>
+                    <div id="outside-node" style="width: 200px; height: 200px;"></div>
+                </Root>
+            `);
+
+            await hover(`#parent-node`);
+
+            await waitFor(() => {
+                const parentNode = expectHTMLQuery(`#parent-node`);
+                const tooltipNode = expectHTMLQuery(`#tooltip-node`);
+                expect(parentNode).domElement().preceding(tooltipNode);
+            });
+
+            // direct click with no mouseout event
+            expectHTMLQuery(`#outside-node`).click();
+
+            await waitFor(() => {
+                expect(query(`#tooltip-node`), `click outside`).to.not.be.domElement();
+            });
+        });
+    });
+
+    describe(`position`, () => {
+        it(`should position relative to parent`, async () => {
+            const { expectHTMLQuery } = testDriver.render(`
+                <script>
+                    import {Root, Tooltip} from '@zeejs/svelte';
+                </script>
+                <Root>
+                    <div
+                        style="
+                            width: 300px;
+                            height: 300px;
+                            display: grid;
+                            justify-items: center;
+                            align-content: center;
+                        "
+                    >
+                        <div id="parent-node" tabIndex="0" style="width: 100px; height: 40px;">
+                            <Tooltip>
+                                <div id="tooltip-node" style="width: 80px; height: 20px;"></div>
+                            </Tooltip>
+                        </div>
+                    </div>
+                </Root>
+            `);
+
+            await hover(`#parent-node`);
+
+            await waitFor(() => {
+                const tooltipNode = expectHTMLQuery(`#tooltip-node`);
+                const parentNode = expectHTMLQuery(`#parent-node`);
+                const tooltipBounds = tooltipNode.getBoundingClientRect();
+                const parentBounds = parentNode.getBoundingClientRect();
+                expect(tooltipBounds.bottom, `tooltip above`).to.be.approximately(
+                    parentBounds.top,
+                    1
+                );
+                expect(
+                    tooltipBounds.right - tooltipBounds.width / 2,
+                    `tooltip x centered`
+                ).to.be.approximately(parentBounds.right - parentBounds.width / 2, 1);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR add a tooltip component.

- [x] pure logic implementation
    - open & close triggers
        - focus (just to initiate open)
        - blur to close (only when mouse is out)
        - mouse over triggering element
        - mouse within opened layer keep tooltip open
        - ~esc to close~ - will be added in a separate PR
    - open & close delay
    - open at the top with auto overflow control
- [x] React component
- [x] Svelte component

**Leftovers:**

- feature: [position, size & overflow abilities](https://github.com/idoros/zeejs/issues/36)
- feature: [catch escape on top layer](https://github.com/idoros/zeejs/issues/35)
- accessibility, caveats & research:
    - in most cases, touch users trigger focus/hover, but also trigger click, eliminating the possibility of getting a label/description without causing the action
    - should tooltip prevent focus & selections on overlay? should tooltip only contain simple text? (I assume there is another component `popupMenu` or `tooltipDialog` to allow a more persistent anchored overlay)
    - how screen readers get the content of a tooltip on an element that doesn't accept focus?
    - tooltip on a disabled element will work for mouse, but not for screen reader, also should tabbing into a disabled button tooltip be allowed?
    - move between anchor and overlay is maintained with an adjustable delay by the developer using the component. there should be some best practices for users that needs more time or even better, a default that takes some user preferences into account.
    - tooltip should be readable on focus - might want to always render it and then move it in the DOM or copy it for visual representation (need more research on what should be used: `aria-labelledby`/`aria-label`/`aria-describedby`/`live region`)
    - need to keep track on (https://www.w3.org/TR/wai-aria-practices/#tooltip & https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus)