### PR TITLE
layout overlay tasks

### DIFF
--- a/packages/browser/src/layout-overlay.ts
+++ b/packages/browser/src/layout-overlay.ts
@@ -104,6 +104,11 @@ export const layoutOverlay = (
     update(overlay);
     return {
         stop: () => {
+            const overlayConfig = overlays.get(overlay);
+            if (overlayConfig) {
+                restoreSize(`width`, overlayConfig, overlay);
+                restoreSize(`height`, overlayConfig, overlay);
+            }
             overlays.delete(overlay);
             if (resizeObserver) {
                 resizeObserver.unobserve(anchor); // ToDo: prevent unobserve if another overlay is connected
@@ -263,13 +268,21 @@ function updateSize(
             initSize[dir] = overlay.style[dir];
         }
         overlay.style[dir] = refRect[dir] + `px`;
-    } else if (initSize[dir] !== UNSET_POS) {
-        if (initSize[dir]) {
-            overlay.style[dir] = initSize[dir];
-        } else {
-            overlay.style.removeProperty(dir);
+    } else {
+        restoreSize(dir, overlayConfig, overlay);
+    }
+}
+function restoreSize(dir: `width` | `height`, overlayConfig: OverlayConfig, overlay: HTMLElement) {
+    const { initSize } = overlayConfig;
+    if (initSize[dir] !== UNSET_POS) {
+        if (initSize[dir] !== UNSET_POS) {
+            if (initSize[dir]) {
+                overlay.style[dir] = initSize[dir];
+            } else {
+                overlay.style.removeProperty(dir);
+            }
+            initSize[dir] = UNSET_POS;
         }
-        initSize[dir] = UNSET_POS;
     }
 }
 function getPosition(pos: OverlayPosition, dir: `x` | `y`, refRect: DOMRect, overlayRect: DOMRect) {

--- a/packages/browser/src/layout-overlay.ts
+++ b/packages/browser/src/layout-overlay.ts
@@ -156,6 +156,8 @@ export const layoutOverlay = (
     };
 };
 
+layoutOverlay.NOT_PLACED = `zeejs--notPlaced`;
+
 function onScroll({ target }: Event) {
     const eventTarget = target instanceof Document ? target.body : target;
     if (eventTarget instanceof Element) {

--- a/packages/browser/src/layout-overlay.ts
+++ b/packages/browser/src/layout-overlay.ts
@@ -28,13 +28,16 @@ export interface OverflowData {
 }
 interface OverlayConfig extends OverlayOptions {
     anchor: Element;
-    initSize: {
+    init: {
         width: string;
         height: string;
+        overflowX: string;
+        overflowY: string;
+        overflow: string;
     };
 }
 
-const UNSET_POS = `zeejs-unset`;
+const UNSET = `zeejs-unset`;
 const affectedOverlays = new Map<Element, Set<HTMLElement>>();
 const overlays = new Map<HTMLElement, OverlayConfig>();
 const anchors = new Map<Element, Set<HTMLElement>>();
@@ -72,7 +75,13 @@ export const layoutOverlay = (
         y: options.y || `center`,
         width: options.width ?? true,
         height: options.height ?? true,
-        initSize: { width: UNSET_POS, height: UNSET_POS },
+        init: {
+            width: UNSET,
+            height: UNSET,
+            overflowX: UNSET,
+            overflowY: UNSET,
+            overflow: overlay.style.overflow,
+        },
         onOverflow:
             options.onOverflow ||
             (() => {
@@ -106,6 +115,12 @@ export const layoutOverlay = (
         stop: () => {
             const overlayConfig = overlays.get(overlay);
             if (overlayConfig) {
+                // restore shorthand overflow first, because browser merges overflow-x/y together
+                if (overlayConfig.init.overflow) {
+                    overlay.style.overflow = overlayConfig.init.overflow;
+                } else {
+                    overlay.style.removeProperty(`overflow`);
+                }
                 restoreSize(`width`, overlayConfig, overlay);
                 restoreSize(`height`, overlayConfig, overlay);
             }
@@ -264,27 +279,35 @@ function updateSize(
     overlayConfig: OverlayConfig,
     overlay: HTMLElement
 ) {
-    const { [dir]: bindDir, initSize } = overlayConfig;
+    const { [dir]: bindDir, init } = overlayConfig;
     if (bindDir) {
-        if (initSize[dir] === UNSET_POS) {
-            initSize[dir] = overlay.style[dir];
+        const overflow = dir === `width` ? `overflowX` : `overflowY`;
+        if (init[dir] === UNSET) {
+            init[dir] = overlay.style[dir];
+            init[overflow] = overlay.style[overflow];
         }
+        overlay.style[overflow] = `auto`;
         overlay.style[dir] = refRect[dir] + `px`;
     } else {
         restoreSize(dir, overlayConfig, overlay);
     }
 }
 function restoreSize(dir: `width` | `height`, overlayConfig: OverlayConfig, overlay: HTMLElement) {
-    const { initSize } = overlayConfig;
-    if (initSize[dir] !== UNSET_POS) {
-        if (initSize[dir] !== UNSET_POS) {
-            if (initSize[dir]) {
-                overlay.style[dir] = initSize[dir];
-            } else {
-                overlay.style.removeProperty(dir);
-            }
-            initSize[dir] = UNSET_POS;
+    const { init } = overlayConfig;
+    if (init[dir] !== UNSET) {
+        const overflow = dir === `width` ? `overflowX` : `overflowY`;
+        if (init[dir]) {
+            overlay.style[dir] = init[dir];
+        } else {
+            overlay.style.removeProperty(dir);
         }
+        if (init[overflow]) {
+            overlay.style[overflow] = init[overflow];
+        } else {
+            overlay.style.removeProperty(overflow);
+        }
+        init[dir] = UNSET;
+        init[overflow] = UNSET;
     }
 }
 function getPosition(pos: OverlayPosition, dir: `x` | `y`, refRect: DOMRect, overlayRect: DOMRect) {

--- a/packages/browser/src/tooltip.ts
+++ b/packages/browser/src/tooltip.ts
@@ -11,8 +11,6 @@ interface TooltipOptions {
     positionY?: OverlayPosition;
 }
 
-const NOT_PLACED = `zeejs--notPlaced`;
-
 export const tooltip = ({
     onToggle,
     anchor,
@@ -103,14 +101,14 @@ export const tooltip = ({
                 width: false,
                 onOverflow: keepInView,
             });
-            overlay.classList.remove(NOT_PLACED);
+            overlay.classList.remove(layoutOverlay.NOT_PLACED);
         } else if (!newOpenState) {
             if (bindPosition) {
                 bindPosition.stop();
                 bindPosition = null;
             }
             if (overlay) {
-                overlay.classList.add(NOT_PLACED);
+                overlay.classList.add(layoutOverlay.NOT_PLACED);
             }
         }
         if (newOpenState !== isOpen) {
@@ -168,7 +166,7 @@ export const tooltip = ({
                 });
             }
         },
-        initialOverlayCSSClass: NOT_PLACED,
+        initialOverlayCSSClass: layoutOverlay.NOT_PLACED,
         stop() {
             unsetAnchor();
             window.removeEventListener(`mousemove`, onMouseMove);

--- a/packages/browser/test/layout-overlay.spec.ts
+++ b/packages/browser/test/layout-overlay.spec.ts
@@ -199,6 +199,28 @@ describe(`layout-overlay`, () => {
             stopA();
             stopB();
         });
+        it(`should restrict overlay size when bound to anchor size`, () => {
+            const { expectQuery, expectHTMLQuery } = testDriver.render(
+                () => `
+                    <div id="anchor" style="background: red;width: 100px; height: 200px; margin: 30px"></div>
+                    <div id="overlay" style="background:green; overflow-y: visible;">
+                        <div style="width: 300px; height: 300px;"></div>
+                    </div>
+                `
+            );
+            const anchor = expectQuery(`#anchor`);
+            const overlay = expectHTMLQuery(`#overlay`);
+
+            const { stop } = layoutOverlay(anchor, overlay);
+
+            expect(overlay.style.overflowX, `overflow-x`).to.equal(`auto`);
+            expect(overlay.style.overflowY, `overflow-y`).to.equal(`auto`);
+
+            stop();
+
+            expect(overlay.style.overflowX, `initial overflow-x`).to.equal(``);
+            expect(overlay.style.overflowY, `initial overflow-y`).to.equal(`visible`);
+        });
         it(`should restore size when stopped`, () => {
             const { expectQuery, expectHTMLQuery } = testDriver.render(
                 () => `

--- a/packages/browser/test/layout-overlay.spec.ts
+++ b/packages/browser/test/layout-overlay.spec.ts
@@ -199,6 +199,32 @@ describe(`layout-overlay`, () => {
             stopA();
             stopB();
         });
+        it(`should restore size when stopped`, () => {
+            const { expectQuery, expectHTMLQuery } = testDriver.render(
+                () => `
+                    <div id="anchor" style="background: red;width: 100px; height: 200px; margin: 30px"></div>
+                    <div id="overlay" style="background:green;"/>
+                `
+            );
+            const anchor = expectQuery(`#anchor`);
+            const overlay = expectHTMLQuery(`#overlay`);
+            let { stop } = layoutOverlay(anchor, overlay);
+
+            stop();
+
+            expect(overlay.style.width, `unset width`).to.equal(``);
+            expect(overlay.style.height, `unset height`).to.equal(``);
+
+            overlay.style.width = `300px`;
+            overlay.style.height = `400px`;
+
+            ({ stop } = layoutOverlay(anchor, overlay));
+
+            stop();
+
+            expect(overlay.style.width, `initial width`).to.equal(`300px`);
+            expect(overlay.style.height, `initial height`).to.equal(`400px`);
+        });
         describe(`document scroll`, () => {
             it(`should update overlay position relative to body`, async () => {
                 const { expectQuery, expectHTMLQuery } = testDriver.render(


### PR DESCRIPTION
This PR combines several tasks for the `layout-overly`:

- fix: restore overlay size after layouting is stopped
- feat: add overflow control 