### PR TITLE
fix: click-outside for layer that was created while clicking

### DIFF
--- a/packages/browser/test/popover.spec.ts
+++ b/packages/browser/test/popover.spec.ts
@@ -3,7 +3,7 @@ import { HTMLTestDriver } from './html-test-driver';
 import { expect } from 'chai';
 import { waitFor } from 'promise-assist';
 
-describe.only(`popover`, () => {
+describe(`popover`, () => {
     let testDriver: HTMLTestDriver;
 
     before('setup test driver', () => (testDriver = new HTMLTestDriver()));


### PR DESCRIPTION
Creating a layer during pointerdown, for example when a layer is rendered via focus, might be catched as clicked-outside of when the mouse is up again.

This PR ignores click-outside for layers that are created between pointerdown and click.