### PR TITLE
fix: invoke click outside root

### DIFF
--- a/packages/browser/src/click-outside.ts
+++ b/packages/browser/src/click-outside.ts
@@ -1,11 +1,7 @@
 import type { DOMLayer } from './root';
 import type { BackdropElements } from './update-layers';
 
-export function watchClickOutside(
-    wrapper: HTMLElement,
-    topLayer: DOMLayer,
-    backdrop: BackdropElements
-) {
+export function watchClickOutside(topLayer: DOMLayer, backdrop: BackdropElements) {
     let pointerDownLayers: ReturnType<DOMLayer['generateDisplayList']> | null = null;
     const onPointerDown = () => {
         // set available layers while mousedown to prevent any layer that
@@ -50,12 +46,12 @@ export function watchClickOutside(
         }
     };
 
-    wrapper.addEventListener(`pointerdown`, onPointerDown, { capture: true });
-    wrapper.addEventListener(`click`, onClick, { capture: true });
+    window.addEventListener(`pointerdown`, onPointerDown, { capture: true });
+    window.addEventListener(`click`, onClick, { capture: true });
     return {
         stop() {
-            wrapper.removeEventListener(`pointerdown`, onPointerDown);
-            wrapper.removeEventListener(`click`, onClick);
+            window.removeEventListener(`pointerdown`, onPointerDown);
+            window.removeEventListener(`click`, onClick);
         },
     };
 }

--- a/packages/browser/test/click-outside.spec.ts
+++ b/packages/browser/test/click-outside.spec.ts
@@ -34,7 +34,7 @@ describe(`click-outside`, () => {
         childLayer.element.appendChild(expectQuery(`#child-node`));
         updateLayers(container, rootLayer, backdrop);
 
-        watchClickOutside(container, rootLayer, backdrop);
+        watchClickOutside(rootLayer, backdrop);
 
         await click(`#root-node`);
 
@@ -63,7 +63,7 @@ describe(`click-outside`, () => {
         rootLayer.createLayer({ settings: { onClickOutside } });
         updateLayers(container, rootLayer, backdrop);
 
-        watchClickOutside(container, rootLayer, backdrop);
+        watchClickOutside(rootLayer, backdrop);
 
         await click(`#root-node`);
 
@@ -97,7 +97,7 @@ describe(`click-outside`, () => {
         deepLayer.element.appendChild(expectQuery(`#deep-node`));
         updateLayers(container, rootLayer, backdrop);
 
-        watchClickOutside(container, rootLayer, backdrop);
+        watchClickOutside(rootLayer, backdrop);
 
         await click(`#root-node`);
 
@@ -133,7 +133,7 @@ describe(`click-outside`, () => {
         bLayer.element.appendChild(expectQuery(`#layerB-node`));
         updateLayers(container, rootLayer, backdrop);
 
-        watchClickOutside(container, rootLayer, backdrop);
+        watchClickOutside(rootLayer, backdrop);
 
         await click(`#root-node`);
 
@@ -173,7 +173,7 @@ describe(`click-outside`, () => {
         backdrop.block.id = `backdrop`;
         updateLayers(container, rootLayer, backdrop);
 
-        watchClickOutside(container, rootLayer, backdrop);
+        watchClickOutside(rootLayer, backdrop);
 
         await click(`#backdrop`);
 
@@ -199,7 +199,7 @@ describe(`click-outside`, () => {
         backdrop.block.id = `backdrop`;
         updateLayers(container, rootLayer, backdrop);
 
-        watchClickOutside(container, rootLayer, backdrop);
+        watchClickOutside(rootLayer, backdrop);
 
         await click(`#backdrop`);
 
@@ -215,7 +215,7 @@ describe(`click-outside`, () => {
         `
         );
         const rootLayer = createRoot();
-        watchClickOutside(container, rootLayer, backdrop);
+        watchClickOutside(rootLayer, backdrop);
         rootLayer.element.appendChild(expectQuery(`#root-node`));
 
         // user: pointer down
@@ -238,5 +238,30 @@ describe(`click-outside`, () => {
 
         // click outside reported
         expect(onLayerClickOutside, `click outside`).to.have.callCount(1);
+    });
+
+    it(`should inform layer on root click (out of root)`, async function () {
+        this.timeout(3000);
+        const onClickOutside = stub();
+        const backdrop = createBackdropParts();
+        const { container, expectQuery } = testDriver.render(
+            () => `
+            <div id="root-node" style="width: 10px; height: 10px; background: green;"></div>
+            <div id="child-node" style="width: 20px; height: 20px; background: red;"></div>
+        `
+        );
+        container.style.width = `10px`;
+        container.style.height = `10px`;
+        const rootLayer = createRoot();
+        const childLayer = rootLayer.createLayer({ settings: { onClickOutside } });
+        rootLayer.element.appendChild(expectQuery(`#root-node`));
+        childLayer.element.appendChild(expectQuery(`#child-node`));
+        updateLayers(container, rootLayer, backdrop);
+
+        watchClickOutside(rootLayer, backdrop);
+
+        await click(`body`);
+
+        expect(onClickOutside, `catch click on root`).to.have.callCount(1);
     });
 });

--- a/packages/react/src/root.tsx
+++ b/packages/react/src/root.tsx
@@ -56,7 +56,7 @@ export const Root = ({ className, style, children }: RootProps) => {
         document.head.appendChild(parts.style);
         rootLayer.element = wrapper.firstElementChild! as HTMLElement;
         const { stop: stopFocus } = watchFocus(wrapper, rootLayer);
-        const { stop: stopClickOutside } = watchClickOutside(wrapper, rootLayer, parts);
+        const { stop: stopClickOutside } = watchClickOutside(rootLayer, parts);
         const { stop: stopMouseInside } = watchMouseInside(wrapper, rootLayer, parts);
         const { stop: stopEscape } = watchEscape(rootLayer);
         updateLayers(wrapper, rootLayer, parts);

--- a/packages/svelte/src/Root.svelte
+++ b/packages/svelte/src/Root.svelte
@@ -27,7 +27,7 @@
 
     onMount(() => {
         const { stop: stopFocus } = watchFocus(wrapper, rootLayer);
-        const { stop: stopClickOutside } = watchClickOutside(wrapper, rootLayer, backdrop);
+        const { stop: stopClickOutside } = watchClickOutside(rootLayer, backdrop);
         const { stop: stopMouseInside } = watchMouseInside(wrapper, rootLayer, backdrop);
         const { stop: stopEscape } = watchEscape(rootLayer);
         onChange();


### PR DESCRIPTION
Click-outside listen on window to catch clicks that are generated out of the root wrapper element.